### PR TITLE
Make HyperTrasformer work well with dtype category (#124)

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -171,7 +171,7 @@ class CategoricalTransformer(BaseTransformer):
         if self.anonymize:
             data = data.map(MAPS[id(self)])
 
-        return data.fillna(np.nan).apply(self._get_value).values
+        return data.fillna(np.nan).apply(self._get_value).to_numpy()
 
     def _normalize(self, data):
         """Normalize data to the range [0, 1].

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -141,3 +141,16 @@ def test_single_category():
     reverse = ht.reverse_transform(transformed)
 
     pd.testing.assert_frame_equal(data, reverse)
+
+
+def test_dtype_category():
+    df = pd.DataFrame({'a': ['a', 'b', 'c']}, dtype='category')
+
+    ht = HyperTransformer()
+    ht.fit(df)
+
+    trans = ht.transform(df)
+
+    rever = ht.reverse_transform(trans)
+
+    pd.testing.assert_frame_equal(df, rever)


### PR DESCRIPTION
Resolve #124: Fix issue in HyperTransformer and CategoricalTransformer that made columns of dtype `category` crash.