### PR TITLE
Ensure CategoricalTransformer works on numerical+nans data

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -115,6 +115,9 @@ class CategoricalTransformer(BaseTransformer):
             end = start + prob
             mean = (start + end) / 2
             std = prob / 6
+            if pd.isnull(value):
+                value = np.nan
+
             intervals[value] = (start, end, mean, std)
             start = end
 
@@ -144,7 +147,11 @@ class CategoricalTransformer(BaseTransformer):
 
     def _get_value(self, category):
         """Get the value that represents this category."""
+        if pd.isnull(category):
+            category = np.nan
+
         mean, std = self.intervals[category][2:]
+
         if self.fuzzy:
             return norm.rvs(mean, std)
 

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pandas as pd
+
+from rdt.transformers import CategoricalTransformer
+
+
+def test_categorical_numerical_nans():
+    """Ensure CategoricalTransformers work on numerical + nan only columns."""
+
+    data = pd.Series([1, 2, float('nan'), np.nan])
+
+    ct = CategoricalTransformer()
+    ct.fit(data)
+    transformed = ct.transform(data)
+    reverse = ct.reverse_transform(transformed)
+
+    pd.testing.assert_series_equal(reverse, data)


### PR DESCRIPTION
Ensure CategoricalTransformer works well on arrays that only contain numerical data and nan values, which previously crashed with a `KeyError`.

Resolve #142 