### PR TITLE
Add dtype_transformers argument to HyperTransformer

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -60,6 +60,7 @@ class HyperTransformer:
     """
 
     _TRANSFORMER_TEMPLATES = {
+        'numerical': NumericalTransformer,
         'integer': NumericalTransformer(dtype=int),
         'float': NumericalTransformer(dtype=float),
         'categorical': CategoricalTransformer,
@@ -67,11 +68,11 @@ class HyperTransformer:
         'one_hot_encoding': OneHotEncodingTransformer(error_on_unknown=False),
         'label_encoding': LabelEncodingTransformer,
         'boolean': BooleanTransformer,
-        'datetime': DatetimeTransformer(),
+        'datetime': DatetimeTransformer,
     }
     _DTYPE_TRANSFORMERS = {
-        'i': 'integer',
-        'f': 'float',
+        'i': 'numerical',
+        'f': 'numerical',
         'O': 'categorical',
         'b': 'boolean',
         'M': 'datetime',

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -142,7 +142,9 @@ class HyperTransformer:
                 transformer = deepcopy(transformer_template)
             elif self.anonymize and transformer_template == CategoricalTransformer:
                 warnings.warn(
-                    'Categorical anonymization is deprecated and will be removed soon.')
+                    'Categorical anonymization is deprecated and will be removed from RDT soon.',
+                    DeprecationWarning
+                )
                 transformer = CategoricalTransformer(anonymize=self.anonymize)
             else:
                 transformer = transformer_template()

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ ignore = D107, D407
 [pylint]
 extension-pkg-whitelist = numpy
 min-similarity-lines = 5
+max-args = 8
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes


### PR DESCRIPTION
Add a `dtype_transformers` argument to the `HyperTransformer` which gives control about which transformer to use for each dtype without having to specify the transformers individually for each column.