### PR TITLE
If transformers is an empty dict, do nothing

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -160,7 +160,7 @@ class HyperTransformer:
             data (pandas.DataFrame):
                 Data to fit the transformers to.
         """
-        if self.transformers:
+        if self.transformers is not None:
             self._transformers = load_transformers(self.transformers)
         else:
             self._transformers = self._analyze(data)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -154,3 +154,17 @@ def test_dtype_category():
     rever = ht.reverse_transform(trans)
 
     pd.testing.assert_frame_equal(df, rever)
+
+
+def test_empty_transformers():
+    """If transformers is an empty dict, do nothing."""
+    data = get_input_data()
+
+    ht = HyperTransformer(transformers={})
+    ht.fit(data)
+
+    transformed = ht.transform(data)
+    reverse = ht.reverse_transform(transformed)
+
+    pd.testing.assert_frame_equal(data, transformed)
+    pd.testing.assert_frame_equal(data, reverse)

--- a/tests/test_hyper_transformer.py
+++ b/tests/test_hyper_transformer.py
@@ -10,7 +10,7 @@ from rdt.transformers import (
     BooleanTransformer, DatetimeTransformer, NumericalTransformer, OneHotEncodingTransformer)
 
 
-class TestHyperTransformerTransformer(TestCase):
+class TestHyperTransformer(TestCase):
 
     def test___init__(self):
         """Test create new instance of HyperTransformer"""


### PR DESCRIPTION
If the `HyperTransformer` is created passing an empty `transformers` dict, the `HT` should not apply any transformations instead of analyzing the data and loading the default transformers.