### PR TITLE
Support 2d ndarrays for Boolean and Datetime transformers

### DIFF
--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -80,6 +80,9 @@ class BooleanTransformer(BaseTransformer):
             data = self.null_transformer.reverse_transform(data)
 
         if isinstance(data, np.ndarray):
+            if data.ndim == 2:
+                data = data[:, 0]
+
             data = pd.Series(data)
 
         data[pd.notnull(data)] = np.round(data[pd.notnull(data)]).astype(bool)

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -316,4 +316,7 @@ class LabelEncodingTransformer(BaseTransformer):
         Returns:
             pandas.Series
         """
+        if isinstance(data, np.ndarray) and (data.ndim == 2):
+            data = data[:, 0]
+
         return pd.Series(data).astype(int).map(self.values_to_categories)

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -110,6 +110,9 @@ class DatetimeTransformer(BaseTransformer):
         if self.nan is not None:
             data = self.null_transformer.reverse_transform(data)
 
+        if isinstance(data, np.ndarray) and (data.ndim == 2):
+            data = data[:, 0]
+
         data[pd.notnull(data)] = np.round(data[pd.notnull(data)]).astype(np.int64)
         if self.strip_constant:
             data = data.astype(float) * self.divider

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -31,6 +31,19 @@ def test_one_hot_numerical_nans():
     pd.testing.assert_series_equal(reverse, data)
 
 
+def test_label_numerical_2d_array():
+    """Ensure LabelEncodingTransformer works on numerical + nan only columns."""
+
+    data = pd.Series([1, 2, 3, 4])
+
+    transformer = LabelEncodingTransformer()
+    transformer.fit(data)
+    transformed = np.array([[0], [1], [2], [3]])
+    reverse = transformer.reverse_transform(transformed)
+
+    pd.testing.assert_series_equal(reverse, data)
+
+
 def test_label_numerical_nans():
     """Ensure LabelEncodingTransformer works on numerical + nan only columns."""
 

--- a/tests/transformers/test_boolean.py
+++ b/tests/transformers/test_boolean.py
@@ -182,3 +182,20 @@ class TestBooleanTransformer(TestCase):
 
         assert isinstance(result, pd.Series)
         np.testing.assert_equal(result.values, expected)
+
+    def test_reverse_transform_2d_ndarray(self):
+        """Test reverse_transform not null values correctly"""
+        # Setup
+        data = np.array([[1.], [0.], [1.]])
+
+        # Run
+        transformer = Mock()
+        transformer.nan = None
+
+        result = BooleanTransformer.reverse_transform(transformer, data)
+
+        # Asserts
+        expected = np.array([True, False, True])
+
+        assert isinstance(result, pd.Series)
+        np.testing.assert_equal(result.values, expected)

--- a/tests/transformers/test_datetime.py
+++ b/tests/transformers/test_datetime.py
@@ -49,3 +49,14 @@ class TestDatetimeTransformer:
 
         expected = pd.to_datetime(['NaT'])
         pd.testing.assert_series_equal(output.to_series(), expected.to_series())
+
+    def test_reverse_transform_2d_ndarray(self):
+        dt = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
+        dtt = DatetimeTransformer(strip_constant=True)
+        dtt.fit(dt)
+
+        transformed = np.array([[18262.], [18293.], [18322.]])
+        output = dtt.reverse_transform(transformed)
+
+        expected = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
+        pd.testing.assert_series_equal(output.to_series(), expected.to_series())


### PR DESCRIPTION
* Add support for `2d ndarray` for `BooleanTransformer`.
* Add tests for those changes.
* Add support for `2d ndarray` for `DatetimeTransformer`.
* Add tests for those changes.
* Add support for `2d ndarray` for the `LabelEncodingTransformer`
* Update tests for the `HyperTransformer` .

Resolves #160 