### PR TITLE
Fix CategoricalTransformer with NaN values to be pickled

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -36,6 +36,16 @@ class CategoricalTransformer(BaseTransformer):
     intervals = None
     dtype = None
 
+    def __setstate__(self, state):
+        """Replace any ``null`` key by the actual ``np.nan`` instance."""
+        intervals = state.get('intervals')
+        if intervals:
+            for key in list(intervals):
+                if pd.isnull(key):
+                    intervals[np.nan] = intervals.pop(key)
+
+        self.__dict__ = state
+
     def __init__(self, fuzzy=False, clip=False):
         self.fuzzy = fuzzy
         self.clip = clip

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -1,3 +1,6 @@
+import pickle
+from io import BytesIO
+
 import numpy as np
 import pandas as pd
 
@@ -16,6 +19,27 @@ def test_categorical_numerical_nans():
     reverse = transformer.reverse_transform(transformed)
 
     pd.testing.assert_series_equal(reverse, data)
+
+
+def test_categoricaltransformer_pickle_nans():
+    """Ensure that CategoricalTransformer can be pickled and loaded with nan value."""
+    # setup
+    data = pd.Series([1, 2, float('nan'), np.nan])
+
+    transformer = CategoricalTransformer()
+    transformer.fit(data)
+
+    # create pickle file on memory
+    bytes_io = BytesIO()
+    pickle.dump(transformer, bytes_io)
+    # rewind
+    bytes_io.seek(0)
+
+    # run
+    pickled_transformer = pickle.load(bytes_io)
+
+    # assert
+    transformed = pickled_transformer.transform(data)
 
 
 def test_one_hot_numerical_nans():

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -28,6 +28,7 @@ def test_categoricaltransformer_pickle_nans():
 
     transformer = CategoricalTransformer()
     transformer.fit(data)
+    transformed = transformer.transform(data)
 
     # create pickle file on memory
     bytes_io = BytesIO()
@@ -39,7 +40,8 @@ def test_categoricaltransformer_pickle_nans():
     pickled_transformer = pickle.load(bytes_io)
 
     # assert
-    transformed = pickled_transformer.transform(data)
+    pickle_transformed = pickled_transformer.transform(data)
+    np.testing.assert_array_equal(pickle_transformed, transformed)
 
 
 def test_one_hot_numerical_nans():


### PR DESCRIPTION
* Add integration test to reproduce the issue.
* Add  `__setstate__` as suggested by @csala that solves this issue by replacign the `nan` values to the current `np.nan` instance.

Resolves #164
