### PR TITLE
Update the release-related Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,26 +159,31 @@ publish-test: dist publish-confirm ## package and upload a release on TestPyPI
 publish: dist publish-confirm ## package and upload a release
 	twine upload dist/*
 
-.PHONY: bumpversion-release
-bumpversion-release: ## Merge master to stable and bumpversion release
+.PHONY: git-merge-master-stable
+git-merge-master-stable: ## Merge master into stable
 	git checkout stable || git checkout -b stable
 	git merge --no-ff master -m"make release-tag: Merge branch 'master' into stable"
-	bumpversion release
-	git push --tags origin stable
 
-.PHONY: bumpversion-release-test
-bumpversion-release-test: ## Merge master to stable and bumpversion release
-	git checkout stable || git checkout -b stable
-	git merge --no-ff master -m"make release-tag: Merge branch 'master' into stable"
-	bumpversion release --no-tag
-	@echo git push --tags origin stable
-
-.PHONY: bumpversion-patch
-bumpversion-patch: ## Merge stable to master and bumpversion patch
+.PHONY: git-merge-stable-master
+git-merge-stable-master: ## Merge stable into master
 	git checkout master
 	git merge stable
-	bumpversion --no-tag patch
+
+.PHONY: git-push
+git-push: ## Simply push the repository to github
 	git push
+
+.PHONY: git-push-tags-stable
+git-push-tags-stable: ## Push tags and stable to github
+	git push --tags origin stable
+
+.PHONY: bumpversion-release
+bumpversion-release: ## Bump the version to the next release
+	bumpversion release
+
+.PHONY: bumpversion-patch
+bumpversion-patch: ## Bump the version to the next patch
+	bumpversion --no-tag patch
 
 .PHONY: bumpversion-candidate
 bumpversion-candidate: ## Bump the version to the next candidate
@@ -194,6 +199,7 @@ bumpversion-major: ## Bump the version the next major skipping the release
 
 .PHONY: bumpversion-revert
 bumpversion-revert: ## Undo a previous bumpversion-release
+	git tag --delete $(shell git tag --points-at HEAD)
 	git checkout master
 	git branch -D stable
 
@@ -231,13 +237,14 @@ check-release: check-clean check-candidate check-master check-history ## Check i
 	@echo "A new release can be made"
 
 .PHONY: release
-release: check-release bumpversion-release publish bumpversion-patch
+release: check-release git-merge-master-stable bumpversion-release git-push-tags-stable \
+	publish git-merge-stable-master bumpversion-patch git-push
 
 .PHONY: release-test
-release-test: check-release bumpversion-release-test publish-test bumpversion-revert
+release-test: check-release git-merge-master-stable bumpversion-release bumpversion-revert
 
 .PHONY: release-candidate
-release-candidate: check-master publish bumpversion-candidate
+release-candidate: check-master publish bumpversion-candidate git-push
 
 .PHONY: release-candidate-test
 release-candidate-test: check-clean check-master publish-test


### PR DESCRIPTION
Update the makefile targets to make them more readable and have a smoother `release-candidate` and `release` processes