### PR TITLE
Automate performance test case creation and add numerical tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-ignore = D107, SFS2, SFS3
+extend-ignore = D107, SFS2, SFS3
 
 [isort]
 line_length = 99
@@ -60,4 +60,4 @@ max-attributes = 11
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
-disable = R0903
+disable = R0903, R0914

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,4 +60,4 @@ max-attributes = 11
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
-disable = R0903, R0914
+disable = R0903, R0913, R0914

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_100000_100000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.1,
-            "memory": 40000000.0
+            "memory": 20000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.001,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.1,
+            "memory": 40000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.001,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.04,
-            "memory": 4000000.0
+            "time": 0.02,
+            "memory": 2000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0004,
-            "memory": 2000000.0
+            "time": 0.0002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.04,
+            "memory": 4000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 400000.0
+            "time": 0.01,
+            "memory": 200000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0003,
-            "memory": 200000.0
+            "time": 0.0001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 400000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_100000_100000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.1,
-            "memory": 20000000.0
+            "memory": 10000000.0
         },
         "transform": {
-            "time": 0.02,
-            "memory": 40000000.0
+            "time": 0.01,
+            "memory": 20000000.0
         },
         "reverse_transform": {
             "time": 0.01,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.1,
+            "memory": 20000000.0
+        },
+        "transform": {
+            "time": 0.02,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 3000000.0
+            "time": 0.02,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
+            "time": 0.003,
+            "memory": 2000000.0
         },
         "reverse_transform": {
-            "time": 0.004,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 3000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 300000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_AlmostConstantIntegerNaNsGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 300000.0
+            "time": 0.01,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
-        },
-        "reverse_transform": {
             "time": 0.003,
             "memory": 200000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.1,
+            "memory": 40000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.001,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_100000_100000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.1,
-            "memory": 40000000.0
+            "memory": 20000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.001,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.04,
+            "memory": 4000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.04,
-            "memory": 4000000.0
+            "time": 0.02,
+            "memory": 2000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0004,
-            "memory": 2000000.0
+            "time": 0.0003,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 400000.0
+            "time": 0.01,
+            "memory": 200000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0003,
-            "memory": 200000.0
+            "time": 0.0001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 400000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_100000_100000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.1,
-            "memory": 20000000.0
+            "memory": 10000000.0
         },
         "transform": {
-            "time": 0.02,
-            "memory": 40000000.0
+            "time": 0.01,
+            "memory": 20000000.0
         },
         "reverse_transform": {
             "time": 0.01,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.1,
+            "memory": 20000000.0
+        },
+        "transform": {
+            "time": 0.02,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 3000000.0
+            "time": 0.02,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
-        },
-        "reverse_transform": {
             "time": 0.004,
             "memory": 2000000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 3000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.02,
-            "memory": 300000.0
+            "time": 0.01,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
-        },
-        "reverse_transform": {
             "time": 0.003,
             "memory": 200000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_ConstantIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.02,
+            "memory": 300000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.1,
+            "memory": 30000000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_100000_100000.json
@@ -10,16 +10,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.1,
-            "memory": 30000000.0
+            "time": 0.03,
+            "memory": 20000000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.003,
-            "memory": 20000000.0
+            "time": 0.001,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_10000_10000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.01,
-            "memory": 3000000.0
+            "memory": 2000000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0005,
-            "memory": 2000000.0
+            "time": 0.0002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 3000000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0005,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_1000_1000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.01,
-            "memory": 400000.0
+            "memory": 200000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0003,
-            "memory": 200000.0
+            "time": 0.0001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 400000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_100000_100000.json
@@ -10,16 +10,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.05,
-            "memory": 30000000.0
+            "time": 0.02,
+            "memory": 10000000.0
         },
         "transform": {
-            "time": 0.03,
-            "memory": 40000000.0
+            "time": 0.02,
+            "memory": 20000000.0
         },
         "reverse_transform": {
-            "time": 0.01,
-            "memory": 20000000.0
+            "time": 0.005,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.05,
+            "memory": 30000000.0
+        },
+        "transform": {
+            "time": 0.03,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_10000_10000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.01,
-            "memory": 3000000.0
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
-        },
-        "reverse_transform": {
             "time": 0.004,
             "memory": 2000000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 3000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_1000_1000.json
@@ -11,15 +11,15 @@
     "expected": {
         "fit": {
             "time": 0.01,
-            "memory": 300000.0
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
-        },
-        "reverse_transform": {
             "time": 0.003,
             "memory": 200000.0
+        },
+        "reverse_transform": {
+            "time": 0.001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 300000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.2,
+            "memory": 40000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.001,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_100000_100000.json
@@ -10,16 +10,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.2,
-            "memory": 40000000.0
+            "time": 0.1,
+            "memory": 20000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0003,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.001,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.04,
+            "memory": 4000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.04,
-            "memory": 4000000.0
+            "time": 0.02,
+            "memory": 2000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0004,
-            "memory": 2000000.0
+            "time": 0.0002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_1000_1000.json
@@ -1,21 +1,25 @@
 {
     "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
     "transformer": "rdt.transformers.numerical.NumericalTransformer",
-    "kwargs": {},
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
     "fit_size": 1000,
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.001,
-            "memory": 83000.0
+            "time": 0.03,
+            "memory": 400000.0
         },
         "transform": {
-            "time": 0.0003,
-            "memory": 35000.0
+            "time": 0.001,
+            "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0001,
-            "memory": 23000.0
+            "time": 0.0003,
+            "memory": 200000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 400000.0
+            "time": 0.01,
+            "memory": 200000.0
         },
         "transform": {
-            "time": 0.001,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0003,
-            "memory": 200000.0
+            "time": 0.0001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_100000_100000.json
@@ -10,16 +10,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.2,
-            "memory": 20000000.0
+            "time": 0.1,
+            "memory": 10000000.0
         },
         "transform": {
-            "time": 0.03,
-            "memory": 40000000.0
+            "time": 0.01,
+            "memory": 20000000.0
         },
         "reverse_transform": {
             "time": 0.01,
-            "memory": 20000000.0
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.2,
+            "memory": 20000000.0
+        },
+        "transform": {
+            "time": 0.03,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.04,
+            "memory": 3000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_10000_10000.json
@@ -10,16 +10,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.04,
-            "memory": 3000000.0
+            "time": 0.02,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
-        },
-        "reverse_transform": {
             "time": 0.004,
             "memory": 2000000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_1000_1000.json
@@ -10,16 +10,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.03,
-            "memory": 300000.0
+            "time": 0.01,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
-        },
-        "reverse_transform": {
             "time": 0.003,
             "memory": 200000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,25 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {
+        "rounding": "auto",
+        "min_value": "auto",
+        "max_value": "auto"
+    },
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.03,
+            "memory": 300000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.001,
+            "time": 0.0003,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0005,
-            "memory": 10000000.0
+            "time": 0.0003,
+            "memory": 4000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.003,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.001,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0005,
+            "memory": 10000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 1000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 1000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 1000000.0
+            "time": 0.001,
+            "memory": 400000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 1000000.0
+            "memory": 400000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 100000.0
+            "time": 0.001,
+            "memory": 50000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 100000.0
+            "memory": 40000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 100000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 100000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 10000000.0
+        },
+        "transform": {
+            "time": 0.03,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.01,
+            "time": 0.004,
             "memory": 10000000.0
         },
         "transform": {
-            "time": 0.03,
-            "memory": 40000000.0
-        },
-        "reverse_transform": {
             "time": 0.01,
             "memory": 20000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
+            "time": 0.004,
+            "memory": 2000000.0
         },
         "reverse_transform": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.AlmostConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 200000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_AlmostConstantIntegerNaNsGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
+            "time": 0.003,
+            "memory": 200000.0
         },
         "reverse_transform": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.003,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0005,
+            "memory": 10000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0003,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0005,
-            "memory": 10000000.0
+            "time": 0.0002,
+            "memory": 4000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 1000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 1000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 1000000.0
+            "time": 0.001,
+            "memory": 400000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0003,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 1000000.0
+            "memory": 400000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 100000.0
+            "time": 0.001,
+            "memory": 50000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 100000.0
+            "memory": 40000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 100000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 100000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.01,
+            "time": 0.004,
             "memory": 10000000.0
         },
         "transform": {
             "time": 0.02,
-            "memory": 40000000.0
+            "memory": 20000000.0
         },
         "reverse_transform": {
-            "time": 0.01,
-            "memory": 20000000.0
+            "time": 0.004,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 10000000.0
+        },
+        "transform": {
+            "time": 0.02,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
+            "time": 0.004,
+            "memory": 2000000.0
         },
         "reverse_transform": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.ConstantIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 200000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_ConstantIntegerNaNsGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
+            "time": 0.003,
+            "memory": 200000.0
         },
         "reverse_transform": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.004,
+            "memory": 10000000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.001,
+            "memory": 10000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.004,
+            "time": 0.002,
             "memory": 10000000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.001,
-            "memory": 10000000.0
+            "time": 0.0003,
+            "memory": 4000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0002,
+            "memory": 1000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0002,
-            "memory": 1000000.0
+            "time": 0.0001,
+            "memory": 400000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 200000.0
+        },
+        "transform": {
+            "time": 0.0004,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 100000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.0004,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 100000.0
+            "memory": 40000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.01,
+            "time": 0.004,
             "memory": 10000000.0
         },
         "transform": {
-            "time": 0.03,
-            "memory": 40000000.0
+            "time": 0.02,
+            "memory": 20000000.0
         },
         "reverse_transform": {
-            "time": 0.01,
-            "memory": 20000000.0
+            "time": 0.005,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 10000000.0
+        },
+        "transform": {
+            "time": 0.03,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
+            "time": 0.004,
+            "memory": 2000000.0
         },
         "reverse_transform": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.003,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
+            "time": 0.004,
+            "memory": 200000.0
         },
         "reverse_transform": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.NormalNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 200000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
-            "time": 0.0005,
-            "memory": 10000000.0
+            "time": 0.0002,
+            "memory": 4000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.003,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0005,
+            "memory": 10000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 1000000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 1000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 1000000.0
+            "time": 0.001,
+            "memory": 400000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0003,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 1000000.0
+            "memory": 400000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
+            "time": 0.001,
             "memory": 100000.0
         },
         "transform": {
-            "time": 0.0005,
+            "time": 0.0002,
             "memory": 10000.0
         },
         "reverse_transform": {
             "time": 0.0001,
-            "memory": 100000.0
+            "memory": 40000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 100000.0
+        },
+        "transform": {
+            "time": 0.0005,
+            "memory": 10000.0
+        },
+        "reverse_transform": {
+            "time": 0.0001,
+            "memory": 100000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_100000_100000.json
@@ -6,16 +6,16 @@
     "transform_size": 100000,
     "expected": {
         "fit": {
-            "time": 0.01,
+            "time": 0.004,
             "memory": 10000000.0
         },
         "transform": {
-            "time": 0.02,
-            "memory": 40000000.0
-        },
-        "reverse_transform": {
             "time": 0.01,
             "memory": 20000000.0
+        },
+        "reverse_transform": {
+            "time": 0.004,
+            "memory": 10000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_100000_100000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_100000_100000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 100000,
+    "transform_size": 100000,
+    "expected": {
+        "fit": {
+            "time": 0.01,
+            "memory": 10000000.0
+        },
+        "transform": {
+            "time": 0.02,
+            "memory": 40000000.0
+        },
+        "reverse_transform": {
+            "time": 0.01,
+            "memory": 20000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_10000_10000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 10000,
+    "transform_size": 10000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 2000000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 4000000.0
+        },
+        "reverse_transform": {
+            "time": 0.003,
+            "memory": 2000000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_10000_10000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_10000_10000.json
@@ -6,16 +6,16 @@
     "transform_size": 10000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 2000000.0
+            "time": 0.001,
+            "memory": 1000000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 4000000.0
+            "time": 0.004,
+            "memory": 2000000.0
         },
         "reverse_transform": {
-            "time": 0.003,
-            "memory": 2000000.0
+            "time": 0.002,
+            "memory": 1000000.0
         }
     }
 }

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_1000_1000.json
@@ -1,0 +1,21 @@
+{
+    "dataset": "tests.performance.datasets.numerical.RandomIntegerNaNsGenerator",
+    "transformer": "rdt.transformers.numerical.NumericalTransformer",
+    "kwargs": {},
+    "fit_size": 1000,
+    "transform_size": 1000,
+    "expected": {
+        "fit": {
+            "time": 0.002,
+            "memory": 200000.0
+        },
+        "transform": {
+            "time": 0.01,
+            "memory": 500000.0
+        },
+        "reverse_transform": {
+            "time": 0.002,
+            "memory": 200000.0
+        }
+    }
+}

--- a/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_1000_1000.json
@@ -6,16 +6,16 @@
     "transform_size": 1000,
     "expected": {
         "fit": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         },
         "transform": {
-            "time": 0.01,
-            "memory": 500000.0
+            "time": 0.004,
+            "memory": 200000.0
         },
         "reverse_transform": {
-            "time": 0.002,
-            "memory": 200000.0
+            "time": 0.001,
+            "memory": 100000.0
         }
     }
 }

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -1,9 +1,13 @@
 """Test whether the performance of the Transformers is the expected one."""
 
+import hashlib
 import importlib
 import json
+import os
 import pathlib
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from tests.performance.profiling import profile_transformer
@@ -22,6 +26,11 @@ def get_instance(obj, **kwargs):
         instance = getattr(importlib.import_module(package), name)(**kwargs)
 
     return instance
+
+
+def get_fqn(obj):
+    """Get the fully qualified name of the given object."""
+    return f'{obj.__module__}.{obj.__name__}'
 
 
 TEST_CASES_PATH = pathlib.Path(__file__).parent / 'test_cases'
@@ -54,11 +63,15 @@ def test_performance(config_path):
     with open(config_path, 'r') as config_file:
         config = json.load(config_file)
 
-    transformer = get_instance(config['transformer'], **config['kwargs'])
-    dataset_gen = get_instance(config['dataset'])
+    transformer_instance = get_instance(config['transformer'], **config['kwargs'])
+    dataset_generator = get_instance(config['dataset'])
 
-    out = profile_transformer(transformer, dataset_gen, config['transform_size'],
-                              config['fit_size'])
+    out = profile_transformer(
+        transformer=transformer_instance,
+        dataset_generator=dataset_generator,
+        fit_size=config['fit_size'],
+        transform_size=config['transform_size'],
+    )
 
     assert out['Fit Time'] < config['expected']['fit']['time']
     assert out['Fit Memory'] < config['expected']['fit']['memory']
@@ -66,3 +79,161 @@ def test_performance(config_path):
     assert out['Transform Memory'] < config['expected']['transform']['memory']
     assert out['Reverse Transform Time'] < config['expected']['reverse_transform']['time']
     assert out['Reverse Transform Memory'] < config['expected']['reverse_transform']['memory']
+
+
+def _round_to_magnitude(value):
+    for digits in range(-15, 15):
+        rounded = np.round(value, digits)
+        if rounded != 0:
+            return rounded
+
+    # We should never reach this line
+    raise ValueError("Value is too big")
+
+
+def find_transformer_boundaries(transformer, dataset_generator, fit_size,
+                                transform_size, iterations=1):
+    """Helper function to find valid candidate boundaries for performance tests.
+
+    The function works by:
+        - Running the profiling multiple times
+        - Averaging out the values for each metric
+        - Multiplying the found values by 10 (next order of magnitude).
+        - Rounding to the found order of magnitude
+
+    As an example, if a method took 0.012 seconds to run, the expected output
+    threshold will be set to 0.1, but if it took 0.016, it will be set to 0.2.
+
+    Args:
+        transformer (Transformer):
+            Transformer instance to profile.
+        dataset_generator (type):
+            Dataset Generator class to use.
+        fit_size (int):
+            Number of values to use when fitting the transformer.
+        transform_size (int):
+            Number of values to use when transforming and reverse transforming.
+        iterations (int):
+            Number of iterations to perform.
+
+    Returns:
+        pd.Series:
+            Candidate values for each metric.
+    """
+    results = [
+        profile_transformer(transformer, dataset_generator, transform_size, fit_size)
+        for _ in range(iterations)
+    ]
+    means = pd.DataFrame(results).mean(axis=0)
+    return (means * 10).apply(_round_to_magnitude)
+
+
+def make_test_case_config(transformer_class, transformer_kwargs, dataset_generator,
+                          fit_size, transform_size, iterations=1, output_path=None,
+                          config_name=None):
+    """Create a Test Case JSON file for the indicated transformer and dataset.
+
+    If output path is not given, the test case is created with the filename
+    ``{dataset_generator}_{fit_size}_{transform_size}.json`` inside the folder
+    ``{transformer_module}/{transformer_class_name}``.
+
+    Args:
+        transformer_class (type):
+            Class of the transformer to use.
+        tranformer_kwargs (dict):
+            Keyword arguments to pass to the transformer.
+        dataset_generator (type):
+            Dataset Generator class.
+        fit_size (int):
+            Number of values to use when fitting the transformer.
+        transform_size (int):
+            Number of values to use when transforming and reverse transforming.
+        iterations (int):
+            Number of iterations to perform.
+        output_path (str):
+            Optional. Path where the output JSON file is written.
+        config_name (str):
+            Name that should be given to this kwargs config. If not given,
+            and default args are used, name is ``default``. Otherwise, a
+            hash is taken.
+    """
+    transformer_instance = transformer_class(**transformer_kwargs)
+    outputs = find_transformer_boundaries(transformer_instance, dataset_generator,
+                                          transform_size, fit_size, iterations)
+    test_case = {
+        'dataset': get_fqn(dataset_generator),
+        'transformer': get_fqn(transformer_class),
+        'kwargs': transformer_kwargs,
+        'fit_size': fit_size,
+        'transform_size': transform_size,
+        'expected': {
+            'fit': {
+                'time': outputs['Fit Time'],
+                'memory': outputs['Fit Memory'],
+            },
+            'transform': {
+                'time': outputs['Transform Time'],
+                'memory': outputs['Transform Memory'],
+            },
+            'reverse_transform': {
+                'time': outputs['Reverse Transform Time'],
+                'memory': outputs['Reverse Transform Memory'],
+            },
+        }
+    }
+    if output_path is None:
+        if config_name:
+            config_str = config_name
+        elif transformer_kwargs:
+            config_hash = hashlib.md5()
+            config_hash.update(json.dumps(sorted(transformer_kwargs)).encode())
+            config_str = config_hash.hexdigest()[0:8]
+        else:
+            config_str = 'default'
+
+        file_name = f'{config_str}_{dataset_generator.__name__}_{fit_size}_{transform_size}.json'
+        module_name = transformer_class.__module__.rsplit('.', 1)[1]
+        output_path = TEST_CASES_PATH / module_name / transformer_class.__name__ / file_name
+
+    os.makedirs(output_path.parent, exist_ok=True)
+    with open(output_path, 'w') as output_file:
+        json.dump(test_case, output_file, indent=4)
+
+    cwd = os.getcwd()
+    if str(output_path).startswith(cwd):
+        output_path = str(output_path)[len(cwd) + 1:]
+
+    print(f'Test case created: {output_path}')
+
+
+def make_test_case_configs(transformers, dataset_generators, fit_transform_sizes, iterations=1):
+    """Create Test Case JSON files for multiple transformers and dataset generators.
+
+    Args:
+        transformers (List[Union[type, tuple[type, kwargs, name]]]):
+            List of transformer classes or transformer_class + kwargs tuples.
+        dataset_generators (List[type]):
+            List of dataset generator classes.
+        fit_transform_sizes (List[tuple[int, int]]):
+            List of tuples indicating fit size and transform size.
+    """
+    for transformer in transformers:
+        if not isinstance(transformer, tuple):
+            transformer_class, transformer_kwargs, config_name = transformer, {}, None
+        elif len(transformer) == 2:
+            transformer_class, transformer_kwargs = transformer
+            config_name = None
+        else:
+            transformer_class, transformer_kwargs, config_name = transformer
+
+        for dataset_generator in dataset_generators:
+            for fit_size, transform_size in fit_transform_sizes:
+                make_test_case_config(
+                    transformer_class=transformer_class,
+                    transformer_kwargs=transformer_kwargs,
+                    dataset_generator=dataset_generator,
+                    fit_size=fit_size,
+                    transform_size=transform_size,
+                    iterations=iterations,
+                    config_name=config_name
+                )

--- a/tests/performance/tests/datasets/test_utils.py
+++ b/tests/performance/tests/datasets/test_utils.py
@@ -23,7 +23,7 @@ def test_add_nulls_float():
     with_nans = utils.add_nans(array)
 
     assert len(with_nans) == 100
-    assert 1 < np.isnan(with_nans).sum() < 100
+    assert 1 <= np.isnan(with_nans).sum() < 100
 
     nans = np.isnan(with_nans)
     np.testing.assert_array_equal(array[~nans], with_nans[~nans])


### PR DESCRIPTION
Add functions to automate the creation of performance test cases.

Usage example:

```python3
In [1]: from tests.performance.test_performance import make_test_case_configs

In [2]: import rdt

In [3]: from tests.performance.datasets import numerical

In [4]: dataset_generators = [
   ...: numerical.RandomIntegerGenerator,
   ...: numerical.RandomIntegerNaNsGenerator,
   ...: numerical.NormalGenerator,
   ...: numerical.NormalNaNsGenerator,
   ...: ]

In [5]: transformers = [
   ...: rdt.transformers.NumericalTransformer,
   ...: (rdt.transformers.NumericalTransformer, {'rounding': 'auto', 'min_value': 'auto', 'max_value': 'auto'}, 'auto')
   ...: ]

In [6]: sizes = [(1000, 1000), (10_000, 10_000)]

In [7]: make_test_case_configs(transformers, dataset_generators, sizes, iterations=10)
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_RandomIntegerNaNsGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_NormalGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/default_NormalNaNsGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_RandomIntegerNaNsGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalGenerator_10000_10000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_1000_1000.json
Test case created: tests/performance/test_cases/numerical/NumericalTransformer/auto_NormalNaNsGenerator_10000_10000.json
```

Also add the test cases for the NumericalTransformer using all the numerical generators and 1k, 10k and 100k values.