### PR TITLE
Boolean transformer fixes

### DIFF
--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -43,7 +43,7 @@ class BooleanTransformer(BaseTransformer):
         if isinstance(data, np.ndarray):
             data = pd.Series(data)
 
-        self.null_transformer = NullTransformer(self.nan, self.null_column)
+        self.null_transformer = NullTransformer(self.nan, self.null_column, copy=True)
         self.null_transformer.fit(data)
 
     def transform(self, data):

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -85,4 +85,4 @@ class BooleanTransformer(BaseTransformer):
 
             data = pd.Series(data)
 
-        return np.round(data).astype('boolean').astype('object')
+        return np.round(data).clip(0, 1).astype('boolean').astype('object')

--- a/tests/integration/transformers/test_boolean.py
+++ b/tests/integration/transformers/test_boolean.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+
+from rdt.transformers import BooleanTransformer
+
+
+class TestBooleanTransformer:
+
+    def test_boolean_some_nans(self):
+        """Test BooleanTransformer on input with some nan values.
+
+        Ensure that the BooleanTransformer can fit, transform, and reverse
+        transform on boolean data with Nones. Expect that the reverse
+        transformed data is the same as the input.
+
+        Input:
+            - boolean data with None values
+        Output:
+            - The reversed transformed data
+        """
+        # Setup
+        data = pd.Series([True, False, None, False])
+        transformer = BooleanTransformer()
+
+        # Run
+        transformer.fit(data)
+        transformed = transformer.transform(data)
+        reverse = transformer.reverse_transform(transformed)
+
+        # Assert
+        pd.testing.assert_series_equal(reverse, data)
+
+    def test_boolean_all_nans(self):
+        """Test BooleanTransformer on input with all nan values.
+
+        Ensure that the BooleanTransformer can fit, transform, and reverse
+        transform on boolean data with all Nones. Expect that the reverse
+        transformed data is the same as the input.
+
+        Input:
+            - 4 rows of all None values
+        Output:
+            - The reversed transformed data
+        """
+        # Setup
+        data = pd.Series([None, None, None, None])
+        transformer = BooleanTransformer()
+
+        # Run
+        transformer.fit(data)
+        transformed = transformer.transform(data)
+        reverse = transformer.reverse_transform(transformed)
+
+        # Assert
+        pd.testing.assert_series_equal(reverse, data)
+
+    def test_boolean_input_unchanged(self):
+        """Test BooleanTransformer on input with some nan values.
+
+        Ensure that the BooleanTransformer can fit, transform, and reverse
+        transform on boolean data with all Nones. Expect that the intermediate
+        transformed data is unchanged.
+
+        Input:
+            - 4 rows of all None values
+        Output:
+            - The reversed transformed data
+        Side effects:
+            - The intermediate transformed data is unchanged.
+        """
+        # Setup
+        data = pd.Series([True, False, None, False])
+        transformer = BooleanTransformer()
+
+        # Run
+        transformer.fit(data)
+        transformed = transformer.transform(data)
+        unchanged_transformed = transformed.copy()
+        reverse = transformer.reverse_transform(transformed)
+
+        # Assert
+        pd.testing.assert_series_equal(reverse, data)
+        np.testing.assert_array_equal(unchanged_transformed, transformed)

--- a/tests/performance/test_cases/boolean/BooleanTransformer/default_RandomSkewedBooleanNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/boolean/BooleanTransformer/default_RandomSkewedBooleanNaNsGenerator_1000_1000.json
@@ -14,7 +14,7 @@
             "memory": 1000000.0
         },
         "reverse_transform": {
-            "time": 0.003,
+            "time": 0.01,
             "memory": 1000000.0
         }
     }

--- a/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_ConstantBooleanNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_ConstantBooleanNaNsGenerator_1000_1000.json
@@ -17,7 +17,7 @@
             "memory": 1000000.0
         },
         "reverse_transform": {
-            "time": 0.002,
+            "time": 0.01,
             "memory": 500000.0
         }
     }

--- a/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_RandomBooleanNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_RandomBooleanNaNsGenerator_1000_1000.json
@@ -17,7 +17,7 @@
             "memory": 1000000.0
         },
         "reverse_transform": {
-            "time": 0.002,
+            "time": 0.01,
             "memory": 500000.0
         }
     }

--- a/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_RandomSkewedBooleanNaNsGenerator_1000_1000.json
+++ b/tests/performance/test_cases/boolean/BooleanTransformer/nan_null_default_RandomSkewedBooleanNaNsGenerator_1000_1000.json
@@ -17,7 +17,7 @@
             "memory": 1000000.0
         },
         "reverse_transform": {
-            "time": 0.002,
+            "time": 0.01,
             "memory": 500000.0
         }
     }

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -199,3 +199,54 @@ class TestBooleanTransformer(TestCase):
 
         assert isinstance(result, pd.Series)
         np.testing.assert_equal(result.values, expected)
+
+    def test_reverse_transform_float_values(self):
+        """Test the ``reverse_transform`` method with decimals.
+
+        Expect that the ``reverse_transform`` method handles decimal inputs
+        correctly by rounding them.
+
+        Input:
+            - Transformed data with decimal values.
+        Output:
+            - Reversed transformed data.
+        """
+        # Setup
+        data = np.array([1.2, 0.32, 1.01])
+        transformer = Mock()
+        transformer.nan = None
+
+        # Run
+        result = BooleanTransformer.reverse_transform(transformer, data)
+
+        # Asserts
+        expected = np.array([True, False, True])
+
+        assert isinstance(result, pd.Series)
+        np.testing.assert_equal(result.values, expected)
+
+    def test_reverse_transform_float_values_out_of_range(self):
+        """Test the ``reverse_transform`` method with decimals that are out of range.
+
+        Expect that the ``reverse_transform`` method handles decimal inputs
+        correctly by rounding them. If the rounded decimal inputs are < 0 or > 1, expect
+        expect them to be clipped.
+
+        Input:
+            - Transformed data with decimal values, some of which round to < 0 or > 1.
+        Output:
+            - Reversed transformed data.
+        """
+        # Setup
+        data = np.array([1.9, -0.7, 1.01])
+        transformer = Mock()
+        transformer.nan = None
+
+        # Run
+        result = BooleanTransformer.reverse_transform(transformer, data)
+
+        # Asserts
+        expected = np.array([True, False, True])
+
+        assert isinstance(result, pd.Series)
+        np.testing.assert_equal(result.values, expected)


### PR DESCRIPTION
- Update `BooleanTransformer` to pass `copy=True` when creating the `NullTransformer`
- In `BooleanTransformer.reverse_transform`, clip the rounded values to `[0, 1]`

Resolves #210 and #211. 