### PR TITLE
Addons implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ serve-docs: view-docs ## compile the docs watching for changes
 dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
+	python rdt/transformers/addons/addons_setup.py
 	ls -l dist
 
 .PHONY: publish-confirm

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -51,7 +51,7 @@ __all__ = [
 
 TRANSFORMERS = {
     transformer.__name__: transformer
-    for transformer in BaseTransformer.__subclasses__()
+    for transformer in BaseTransformer.get_subclasses()
 }
 
 DEFAULT_TRANSFORMERS = {

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -1,7 +1,11 @@
 """Transformers module."""
 
+import importlib
+import json
+import os
 from collections import defaultdict
 from functools import lru_cache
+from glob import glob
 
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BooleanTransformer
@@ -10,6 +14,28 @@ from rdt.transformers.categorical import (
 from rdt.transformers.datetime import DatetimeTransformer
 from rdt.transformers.null import NullTransformer
 from rdt.transformers.numerical import GaussianCopulaTransformer, NumericalTransformer
+
+
+def _load_addons():
+    addons = []
+    addons_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'addons')
+    for addon_json_path in glob(f'{addons_path}/*/*.json'):
+        with open(addon_json_path, 'r', encoding='utf-8') as addon_json_file:
+            transformers = json.load(addon_json_file).get('transformers', [])
+            for transformer in transformers:
+                transformer = transformer.split('.')
+                module = '.'.join(transformer[:-1])
+                module = importlib.import_module(module)
+
+                transformer = transformer[-1]
+                transformer_class = getattr(module, transformer)
+                globals()[transformer] = transformer_class
+                addons.append(transformer)
+
+    return addons
+
+
+ADDONS = _load_addons()
 
 __all__ = [
     'BaseTransformer',
@@ -21,13 +47,13 @@ __all__ = [
     'NullTransformer',
     'OneHotEncodingTransformer',
     'LabelEncodingTransformer',
-]
-
+] + ADDONS
 
 TRANSFORMERS = {
     transformer.__name__: transformer
-    for transformer in BaseTransformer.get_subclasses()
+    for transformer in BaseTransformer.__subclasses__()
 }
+
 DEFAULT_TRANSFORMERS = {
     'numerical': NumericalTransformer,
     'integer': NumericalTransformer(dtype=int),

--- a/rdt/transformers/addons/README.md
+++ b/rdt/transformers/addons/README.md
@@ -1,0 +1,31 @@
+<p align="left">
+  <a href="https://dai.lids.mit.edu">
+    <img width=15% src="https://dai.lids.mit.edu/wp-content/uploads/2018/06/Logo_DAI_highres.png" alt="DAI-Lab" />
+  </a>
+  <i>An Open Source Project from the <a href="https://dai.lids.mit.edu">Data to AI Lab, at MIT</a></i>
+</p>
+
+[![Development Status](https://img.shields.io/badge/Development%20Status-2%20--%20Pre--Alpha-yellow)](https://pypi.org/search/?c=Development+Status+%3A%3A+2+-+Pre-Alpha)
+[![PyPi Shield](https://img.shields.io/pypi/v/RDT.svg)](https://pypi.python.org/pypi/RDT)
+[![Unit Tests](https://github.com/sdv-dev/RDT/actions/workflows/unit.yml/badge.svg)](https://github.com/sdv-dev/RDT/actions/workflows/unit.yml)
+[![Downloads](https://pepy.tech/badge/rdt)](https://pepy.tech/project/rdt)
+[![Coverage Status](https://codecov.io/gh/sdv-dev/RDT/branch/master/graph/badge.svg)](https://codecov.io/gh/sdv-dev/RDT)
+
+<img align="center" width=40% src="docs/images/rdt-logo.png">
+
+* Website: https://sdv.dev
+* Documentation: https://sdv.dev/SDV
+* Repository: https://github.com/sdv-dev/RDT
+* License: [MIT](https://github.com/sdv-dev/RDT/blob/master/LICENSE)
+* Development Status: [Pre-Alpha](https://pypi.org/search/?c=Development+Status+%3A%3A+2+-+Pre-Alpha)
+
+# Overview
+
+**RDT** is a Python library used to transform data for data science libraries and preserve
+the transformations in order to revert them as needed.
+
+# Addons
+
+**RDT** addons are families of transformers that are optionally installed to provide
+a wider range of transformers that can be optionally installed to the main package.
+

--- a/rdt/transformers/addons/addons_setup.py
+++ b/rdt/transformers/addons/addons_setup.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script for the addons packages."""
+
+import json
+import os
+import sys
+from copy import deepcopy
+from glob import glob
+from tempfile import TemporaryDirectory
+
+from setuptools import find_namespace_packages, setup
+
+import rdt
+
+with open('README.md', encoding='utf-8') as readme_file:
+    README = readme_file.read()
+
+RDT_VERSION = rdt.__version__
+ADDONS_PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+def _build_setup(addon_json):
+
+    with open(addon_json, 'r', encoding='utf-8') as f:
+        addon = json.load(f)
+
+    addon_name = addon.get('name')
+    addon_module = addon.get('transformers')[0].split('.')
+    addon_module = '.'.join(addon_module[:-2])
+
+    install_requires = [f'rdt>={RDT_VERSION}']
+    install_requires.extend(addon.get('requirements', []))
+
+    # this does something
+    setup(
+        author='MIT Data To AI Lab',
+        author_email='dailabmit@gmail.com',
+        classifiers=[
+            'Development Status :: 2 - Pre-Alpha',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: MIT License',
+            'Natural Language :: English',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+        ],
+        description='Reversible Data Transforms',
+        include_package_data=True,
+        install_requires=install_requires,
+        keywords=['rdt', addon_name],
+        license='MIT license',
+        long_description=README,
+        long_description_content_type='text/markdown',
+        name=addon_name,
+        packages=find_namespace_packages(include=[addon_module]),
+        python_requires='>=3.6,<3.9',
+        url='https://github.com/sdv-dev/RDT',
+        version=RDT_VERSION,
+        zip_safe=False,
+    )
+
+
+def _run():
+    families = deepcopy(sys.argv[1:])
+
+    all_families = [
+        family
+        for family in os.listdir('.')
+        if os.path.isdir(family)
+    ]
+
+    families = list(set(families).intersection(set(all_families)))
+
+    for addon in glob(f'{ADDONS_PATH}/*/*.json'):
+        with TemporaryDirectory() as temp_dir:
+            build_command = [
+                'addons_setup.py', 'bdist_wheel', '--dist-dir', 'dist', '--bdist-dir',
+                temp_dir, 'sdist', '--dist-dir', 'dist', 'egg_info', '--egg-base', temp_dir
+            ]
+
+            sys.argv = build_command
+
+            if not families:
+                _build_setup(addon)
+
+            else:
+                if os.path.basename(os.path.dirname(addon)) in families:
+                    _build_setup(addon)
+
+
+_run()

--- a/rdt/transformers/addons/addons_setup.py
+++ b/rdt/transformers/addons/addons_setup.py
@@ -66,9 +66,15 @@ def _build_setup(addon_json):
 
 
 def _run():
+
     sys_argv = deepcopy(sys.argv)
     path = sys.argv[0]
     base_path = os.path.realpath(path).replace(path, '')
+
+    # clear build if exists
+    build_path = os.path.join(base_path, 'build')
+    if os.path.exists(build_path):
+        shutil.rmtree(build_path)
 
     families = deepcopy(sys.argv[1:])
 

--- a/rdt/transformers/addons/addons_setup.py
+++ b/rdt/transformers/addons/addons_setup.py
@@ -13,7 +13,6 @@ from tempfile import TemporaryDirectory
 
 from setuptools import find_namespace_packages, setup
 
-
 import rdt
 
 with open('README.md', encoding='utf-8') as readme_file:
@@ -67,7 +66,6 @@ def _build_setup(addon_json):
 
 def _run():
 
-    sys_argv = deepcopy(sys.argv)
     path = sys.argv[0]
     base_path = os.path.realpath(path).replace(path, '')
 
@@ -77,7 +75,6 @@ def _run():
         shutil.rmtree(build_path)
 
     families = deepcopy(sys.argv[1:])
-
     all_families = [
         family
         for family in os.listdir('.')
@@ -85,7 +82,6 @@ def _run():
     ]
 
     families = list(set(families).intersection(set(all_families)))
-
     for addon in glob(f'{ADDONS_PATH}/*/*.json'):
         with TemporaryDirectory() as temp_dir:
             build_command = [
@@ -93,9 +89,8 @@ def _run():
                 'sdist', '--dist-dir', 'dist', 'egg_info', '--egg-base', temp_dir
             ]
 
-            sys.argv = deepcopy(build_command)
-
             base_name = os.path.basename(os.path.dirname(addon))
+            sys.argv = deepcopy(build_command)
 
             if not families:
                 _build_setup(addon)
@@ -104,12 +99,12 @@ def _run():
                 if os.path.basename(os.path.dirname(addon)) in families:
                     _build_setup(addon)
 
-            remove = os.path.join(
+            remove_addon_build = os.path.join(
                 base_path, 'build', 'lib', 'rdt', 'transformers', 'addons', base_name
             )
 
             # delete only the processed addon folder
-            shutil.rmtree(remove)
+            shutil.rmtree(remove_addon_build)
 
 
 _run()

--- a/rdt/transformers/addons/identity/__init__.py
+++ b/rdt/transformers/addons/identity/__init__.py
@@ -1,0 +1,1 @@
+"""Identity addons module."""

--- a/rdt/transformers/addons/identity/config.json
+++ b/rdt/transformers/addons/identity/config.json
@@ -1,0 +1,6 @@
+{
+    "name": "rdt_identity",
+    "transformers": [
+        "rdt.transformers.addons.identity.identity.IdentityTransformer"
+    ]
+}

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -20,7 +20,7 @@ class IdentityTransformer(BaseTransformer):
             data (pandas.Series or numpy.ndarray):
                 Data to fit the transformer to.
         """
-        self.INPUT_TYPES = {
+        self.INPUT_TYPE = {
             column: None
             for column in self.columns
         }
@@ -40,7 +40,7 @@ class IdentityTransformer(BaseTransformer):
         Returns:
             pandas.DataFrame or pandas.Series
         """
-        return columns_data
+        return data
 
     def _reverse_transform(self, data):
         """Return the same input data.

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -20,9 +20,10 @@ class IdentityTransformer(BaseTransformer):
             columns_data (pandas.Series or numpy.ndarray):
                 Data to fit the transformer to.
         """
-        pass
+        self.INPUT_TYPE = dict(columns_data.dtypes)
+        self.OUTPUT_TYPES = dict(columns_data.dtypes)
 
-    def _transform(self, columns_data):
+    def transform(self, columns_data):
         """Return the same input data.
 
         Args:
@@ -34,7 +35,7 @@ class IdentityTransformer(BaseTransformer):
         """
         return columns_data
 
-    def _reverse_transform(self, columns_data):
+    def reverse_transform(self, columns_data):
         """Return the same input data.
 
         Args:

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -10,9 +10,6 @@ class IdentityTransformer(BaseTransformer):
     of this data is equal to the input.
     """
 
-    INPUT_TYPE = None
-    OUTPUT_TYPES = None
-
     def _fit(self, data):
         """Fit the transformer to the data.
 
@@ -20,11 +17,6 @@ class IdentityTransformer(BaseTransformer):
             data (pandas.Series or numpy.ndarray):
                 Data to fit the transformer to.
         """
-        self.INPUT_TYPE = {
-            column: None
-            for column in self.columns
-        }
-
         self.OUTPUT_TYPES = {
             column: None
             for column in self.columns

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -13,15 +13,15 @@ class IdentityTransformer(BaseTransformer):
     INPUT_TYPE = None
     OUTPUT_TYPES = None
 
-    def _fit(self, columns_data):
+    def _fit(self, data):
         """Fit the transformer to the data.
 
         Args:
             columns_data (pandas.Series or numpy.ndarray):
                 Data to fit the transformer to.
         """
-        self.INPUT_TYPE = dict(columns_data.dtypes)
-        self.OUTPUT_TYPES = dict(columns_data.dtypes)
+        self.INPUT_TYPE = dict(data.dtypes)
+        self.OUTPUT_TYPES = dict(data.dtypes)
 
     def transform(self, columns_data):
         """Return the same input data.

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -17,32 +17,39 @@ class IdentityTransformer(BaseTransformer):
         """Fit the transformer to the data.
 
         Args:
-            columns_data (pandas.Series or numpy.ndarray):
+            data (pandas.Series or numpy.ndarray):
                 Data to fit the transformer to.
         """
-        self.INPUT_TYPE = dict(data.dtypes)
-        self.OUTPUT_TYPES = dict(data.dtypes)
+        self.INPUT_TYPES = {
+            column: None
+            for column in self.columns
+        }
 
-    def transform(self, columns_data):
+        self.OUTPUT_TYPES = {
+            column: None
+            for column in self.columns
+        }
+
+    def _transform(self, data):
         """Return the same input data.
 
         Args:
-            columns_data (pandas.DataFrame or pandas.Series):
+            data (pandas.Series or numpy.ndarray):
                 Data to transform.
 
         Returns:
-            numpy.ndarray:
+            pandas.DataFrame or pandas.Series
         """
         return columns_data
 
-    def reverse_transform(self, columns_data):
+    def _reverse_transform(self, data):
         """Return the same input data.
 
         Args:
-            columns_data (numpy.ndarray):
+            data (pandas.Series or numpy.ndarray):
                 Data to revert.
 
         Returns:
-            pandas.Series
+            pandas.DataFrame or pandas.Series
         """
-        return columns_data
+        return data

--- a/rdt/transformers/addons/identity/identity.py
+++ b/rdt/transformers/addons/identity/identity.py
@@ -1,0 +1,47 @@
+"""IdentityTransformer module."""
+
+from rdt.transformers.base import BaseTransformer
+
+
+class IdentityTransformer(BaseTransformer):
+    """Identity transformer that produces the same data.
+
+    This transformer is intended for testing purposes only. The transform and reverse transform
+    of this data is equal to the input.
+    """
+
+    INPUT_TYPE = None
+    OUTPUT_TYPES = None
+
+    def _fit(self, columns_data):
+        """Fit the transformer to the data.
+
+        Args:
+            columns_data (pandas.Series or numpy.ndarray):
+                Data to fit the transformer to.
+        """
+        pass
+
+    def _transform(self, columns_data):
+        """Return the same input data.
+
+        Args:
+            columns_data (pandas.DataFrame or pandas.Series):
+                Data to transform.
+
+        Returns:
+            numpy.ndarray:
+        """
+        return columns_data
+
+    def _reverse_transform(self, columns_data):
+        """Return the same input data.
+
+        Args:
+            columns_data (numpy.ndarray):
+                Data to revert.
+
+        Returns:
+            pandas.Series
+        """
+        return columns_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,4 +61,3 @@ ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
 disable = R0801, R0903, R0913, R0914, C0209, W0223, W0221, W0237
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ universal = 1
 
 [flake8]
 max-line-length = 99
-exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
+exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints, rdt/transformers/__init__.py
 extend-ignore = D107, SFS2, SFS3
 
 [isort]
@@ -60,4 +60,5 @@ max-attributes = 11
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
-disable = R0801, R0903, R0913, R0914, C0209, W0223, W0221, W0237
+disable = R0903, R0913, R0914, C0209
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,5 +60,5 @@ max-attributes = 11
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
-disable = R0903, R0913, R0914, C0209
+disable = R0801, R0903, R0913, R0914, C0209, W0223, W0221, W0237
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+import json
+import os
+from glob import glob
+from setuptools import setup, find_namespace_packages
 
 with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()
@@ -32,6 +35,14 @@ tests_require = [
     'jupyter>=1.0.0,<2',
     'rundoc>=0.4.3,<0.5',
 ]
+
+addons_require = []
+
+for addon_json in glob('rdt/transformers/addons/*/*.json'):
+    with open(addon_json, 'r', encoding='utf-8') as addon_json_file:
+        requirements = json.load(addon_json_file).get('requirements')
+        if requirements:
+            addons_require.extend(requirements)
 
 development_requires = [
     # general
@@ -85,8 +96,8 @@ setup(
     description='Reversible Data Transforms',
     extras_require={
         'copulas': copulas_requires,
-        'test': tests_require + copulas_requires,
-        'dev': development_requires + tests_require + copulas_requires,
+        'test': tests_require + copulas_requires + addons_require,
+        'dev': development_requires + tests_require + copulas_requires + addons_require,
     },
     include_package_data=True,
     install_requires=install_requires,
@@ -95,7 +106,7 @@ setup(
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/markdown',
     name='rdt',
-    packages=find_packages(include=['rdt', 'rdt.*']),
+    packages=find_namespace_packages(include=['rdt', 'rdt.transformers']),
     python_requires='>=3.6,<3.9',
     setup_requires=setup_requires,
     test_suite='tests',

--- a/tests/integration/transformers/addons/identity/test_indentity.py
+++ b/tests/integration/transformers/addons/identity/test_indentity.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+
+from rdt.transformers import IdentityTransformer
+
+
+class TestIdentityTransformer:
+
+    def test_fit(self):
+        data = pd.DataFrame({
+            'a': np.array([1, 2, 3]),
+            'b': np.array(['a', 'b', 'c']),
+            'c': np.array([1., 2., 3.])
+        })
+
+        instance = IdentityTransformer()
+        instance.fit(data, columns=['a', 'b'])
+
+    def test_transform(self):
+        data = pd.DataFrame({
+            'a': np.array([1, 2, 3]),
+            'b': np.array(['a', 'b', 'c']),
+            'c': np.array([1., 2., 3.])
+        })
+
+        instance = IdentityTransformer()
+        instance.fit(data, columns=['a', 'b'])
+        transformed = instance.transform(data)
+
+        # assert
+        pd.testing.assert_frame_equal(data, transformed)
+
+    def test_reverse_transform(self):
+        data = pd.DataFrame({
+            'a': np.array([1, 2, 3]),
+            'b': np.array(['a', 'b', 'c']),
+            'c': np.array([1., 2., 3.])
+        })
+
+        instance = IdentityTransformer()
+        instance.fit(data, columns=['a', 'b'])
+        reverse_transformed = instance.reverse_transform(data)
+
+        # assert
+        pd.testing.assert_frame_equal(data, reverse_transformed)

--- a/tests/unit/transformers/addons/identity/test_indentity.py
+++ b/tests/unit/transformers/addons/identity/test_indentity.py
@@ -30,18 +30,12 @@ class TestIdentityTransformer(TestCase):
         IdentityTransformer._fit(instance, data)
 
         # assert
-        expected_input_type = {
-            'a': None,
-            'b': None,
-            'c': None,
-        }
         expected_output_types = {
             'a': None,
             'b': None,
             'c': None,
         }
 
-        assert instance.INPUT_TYPE == expected_input_type
         assert instance.OUTPUT_TYPES == expected_output_types
 
     def test__transform(self):

--- a/tests/unit/transformers/addons/identity/test_indentity.py
+++ b/tests/unit/transformers/addons/identity/test_indentity.py
@@ -9,73 +9,80 @@ from rdt.transformers import IdentityTransformer
 
 class TestIdentityTransformer(TestCase):
 
-    def test___init__(self):
-        instance = IdentityTransformer()
-        assert instance.INPUT_TYPE is None
-        assert instance.OUTPUT_TYPES is None
-
-    def test_fit(self):
-        # setup
-        data = pd.DataFrame({
-            'a': np.array([1, 2, 3]),
-            'b': np.array(['a', 'b', 'c']),
-            'c': np.array([1., 2., 3.])
-        })
-
-        _fit_mock = Mock()
-        instance = IdentityTransformer()
-        instance._fit = _fit_mock
-
-        instance.INPUT_TYPE = {'a': 'int', 'b': 'object'}
-        instance.OUTPUT_TYPES = {'a': 'int', 'b': 'object'}
-
-        # run
-        instance.fit(data, columns=['a', 'b'])
-
-        # assert
-        _fit_data_arg = _fit_mock.call_args[0][0]
-        pd.testing.assert_frame_equal(data[['a', 'b']], _fit_data_arg)
-
     def test__fit(self):
+        """Test ``IdentityTransformer._fit`` function.
+
+        The ``_fit`` function is expected to learn the columns ``INPUT_TYPE`` and
+        ``OUTPUT_COLUMNS`` from the ``self.columns``.
+
+        Setup:
+            - mock self.columns to be a list with values.
+        Input:
+            - ``data``, a ``numpy.ndarray`` with numerical values.
+        Output:
+            - n/a
+        """
         # setup
-        data = pd.DataFrame({
-            'a': np.array([1, 2, 3]),
-            'b': np.array(['a', 'b', 'c']),
-            'c': np.array([1., 2., 3.])
-        })
-        instance = IdentityTransformer()
+        instance = Mock()
+        instance.columns = ['a', 'b', 'c']
 
         # run
-        instance.fit(data, columns=['a', 'b'])
+        data = np.array([0.5, 0.6, 0.7])
+        IdentityTransformer._fit(instance, data)
 
         # assert
-        dtypes = data.dtypes[['a', 'b']]
+        expected_input_type = {
+            'a': None,
+            'b': None,
+            'c': None,
+        }
+        expected_output_types = {
+            'a': None,
+            'b': None,
+            'c': None,
+        }
 
-        instance.INPUT_TYPE == dict(dtypes)
-        instance.OUTPUT_TYPES == dict(dtypes)
+        assert instance.INPUT_TYPE == expected_input_type
+        assert instance.OUTPUT_TYPES == expected_output_types
 
-    def test_transform(self):
-        data = pd.DataFrame({
-            'a': np.array([1, 2, 3]),
-            'b': np.array(['a', 'b', 'c']),
-            'c': np.array([1., 2., 3.])
-        })
 
-        instance = IdentityTransformer()
-        transformed = instance.transform(data)
+    def test__transform(self):
+        """Test ``IdentityTransformer._transform`` function.
+
+        The ``_transform`` function is expected to return the input object without modifying it.
+
+        Input:
+            - An `object` instance.
+        Output:
+            - Same ``object`` as input, unmodified.
+        """
+        # setup
+        instance = Mock()
+        input_object = object()
+
+        # run
+        output_object = IdentityTransformer._transform(instance, input_object)
 
         # assert
-        pd.testing.assert_frame_equal(data, transformed)
+        assert input_object == output_object
 
-    def test_reverse_transform(self):
-        data = pd.DataFrame({
-            'a': np.array([1, 2, 3]),
-            'b': np.array(['a', 'b', 'c']),
-            'c': np.array([1., 2., 3.])
-        })
+    def test__reverse_transform(self):
+        """Test ``IdentityTransformer._reverse_transform`` function.
 
-        instance = IdentityTransformer()
-        reverse_transformed = instance.reverse_transform(data)
+        The ``_reverse_transform`` function is expected to return the input object without
+        modifying it.
+
+        Input:
+            - An `object` instance.
+        Output:
+            - Same ``object`` as input, unmodified.
+        """
+        # setup
+        instance = Mock()
+        input_object = object()
+
+        # run
+        output_object = IdentityTransformer._transform(instance, input_object)
 
         # assert
-        pd.testing.assert_frame_equal(data, reverse_transformed)
+        assert input_object == output_object

--- a/tests/unit/transformers/addons/identity/test_indentity.py
+++ b/tests/unit/transformers/addons/identity/test_indentity.py
@@ -1,20 +1,58 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
 import numpy as np
 import pandas as pd
 
 from rdt.transformers import IdentityTransformer
 
 
-class TestIdentityTransformer:
+class TestIdentityTransformer(TestCase):
+
+    def test___init__(self):
+        instance = IdentityTransformer()
+        assert instance.INPUT_TYPE is None
+        assert instance.OUTPUT_TYPES is None
 
     def test_fit(self):
+        # setup
         data = pd.DataFrame({
             'a': np.array([1, 2, 3]),
             'b': np.array(['a', 'b', 'c']),
             'c': np.array([1., 2., 3.])
         })
 
+        _fit_mock = Mock()
         instance = IdentityTransformer()
+        instance._fit = _fit_mock
+
+        instance.INPUT_TYPE = {'a': 'int', 'b': 'object'}
+        instance.OUTPUT_TYPES = {'a': 'int', 'b': 'object'}
+
+        # run
         instance.fit(data, columns=['a', 'b'])
+
+        # assert
+        _fit_data_arg = _fit_mock.call_args[0][0]
+        pd.testing.assert_frame_equal(data[['a', 'b']], _fit_data_arg)
+
+    def test__fit(self):
+        # setup
+        data = pd.DataFrame({
+            'a': np.array([1, 2, 3]),
+            'b': np.array(['a', 'b', 'c']),
+            'c': np.array([1., 2., 3.])
+        })
+        instance = IdentityTransformer()
+
+        # run
+        instance.fit(data, columns=['a', 'b'])
+
+        # assert
+        dtypes = data.dtypes[['a', 'b']]
+
+        instance.INPUT_TYPE == dict(dtypes)
+        instance.OUTPUT_TYPES == dict(dtypes)
 
     def test_transform(self):
         data = pd.DataFrame({
@@ -24,7 +62,6 @@ class TestIdentityTransformer:
         })
 
         instance = IdentityTransformer()
-        instance.fit(data, columns=['a', 'b'])
         transformed = instance.transform(data)
 
         # assert
@@ -38,7 +75,6 @@ class TestIdentityTransformer:
         })
 
         instance = IdentityTransformer()
-        instance.fit(data, columns=['a', 'b'])
         reverse_transformed = instance.reverse_transform(data)
 
         # assert

--- a/tests/unit/transformers/addons/identity/test_indentity.py
+++ b/tests/unit/transformers/addons/identity/test_indentity.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 import numpy as np
-import pandas as pd
 
 from rdt.transformers import IdentityTransformer
 
@@ -44,7 +43,6 @@ class TestIdentityTransformer(TestCase):
 
         assert instance.INPUT_TYPE == expected_input_type
         assert instance.OUTPUT_TYPES == expected_output_types
-
 
     def test__transform(self):
         """Test ``IdentityTransformer._transform`` function.


### PR DESCRIPTION
### Addons implementation

* New folder structure to contain the different addon families.
    * No `__init__.py` within this folder in order to dec
* New `identity` addon which contains:
    * `IdentityTransformer` : A simple test transformer which returns the input data.
    * Add integration tests for this transformer
* `addons_setup.py` : A generic `setup.py` file that creates distribution packages for `pypi`. **Bear in mind** this has to be run from the root of the project.
* Update to `Makefile` to run `addons_setup.py` when `make dist` is called (this creates a distribution for all the addons, however it can manually be triggered to only produce a single package by running `python rdt/transformers/addons/addons_setup.py <name of family>`.
* Dynamic import for installed addons within the `rdt/transformers/__init__.py` to allow the end user to import directly from `rdt.transformers`.


Resolve #225 