### PR TITLE
Update pylint rules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,5 +60,5 @@ max-attributes = 11
 ignore-comments = yes
 ignore-docstrings = yes
 ignore-imports = yes
-disable = R0903, R0913, R0914
+disable = R0903, R0913, R0914, C0209
 


### PR DESCRIPTION
When using the newest release of pylint, I get the following errors

```
invoke lint
************* Module rdt
rdt/__init__.py:56:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module rdt.hyper_transformer
rdt/hyper_transformer.py:130:33: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
rdt/hyper_transformer.py:187:37: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
rdt/hyper_transformer.py:226:16: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module rdt.transformers.numerical
rdt/transformers/numerical.py:297:24: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
```

Since we still support other ways of formatting strings, we can add C0209 to the list of disabled rules in setup.cfg.