### PR TITLE
Create ways for HyperTransformer to know which transformers to apply to each data type #232

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -1,6 +1,8 @@
 """Hyper transformer module."""
 
+import inspect
 import re
+import sys
 from copy import deepcopy
 
 import numpy as np
@@ -73,6 +75,19 @@ class HyperTransformer:
         'b': 'boolean',
         'M': 'datetime',
     }
+
+    @staticmethod
+    def get_transformers_by_type():
+        data_type_transformers = dict()
+        transformer_classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
+        for (_, transformer) in transformer_classes:
+            try:
+                input_type = transformer.get_input_type()
+                transformers_for_type = data_type_transformers.get(input_type, [])
+                transformers_for_type.append(transformer)
+                data_type_transformers.update({input_type, transformers_for_type})
+            except:
+                pass
 
     def __init__(self, transformers=None, copy=True, dtypes=None, dtype_transformers=None):
         self.transformers = transformers

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -93,7 +93,14 @@ class HyperTransformer:
 
     @staticmethod
     def get_transformers_by_type():
-        data_type_transformers = dict()
+        """Build a ``dict`` mapping data types to valid existing transformers for that type.
+
+        Returns:
+                dict:
+                    Mapping of data types to a list of existing transformers that take that
+                    type as an input.
+        """
+        data_type_transformers = {}
         transformer_classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
         for (_, transformer) in transformer_classes:
             try:

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -75,6 +75,21 @@ class HyperTransformer:
         'b': 'boolean',
         'M': 'datetime',
     }
+    DEFAULT_TRANSFORMERS = {
+        'numerical': NumericalTransformer,
+        'integer': NumericalTransformer(dtype=int),
+        'float': NumericalTransformer(dtype=float),
+        'categorical': CategoricalTransformer(fuzzy=True),
+        'boolean': BooleanTransformer,
+        'datetime': DatetimeTransformer,
+    }
+    _DTYPES_TO_DATA_TYPES = {
+        'i': 'integer',
+        'f': 'float',
+        'O': 'categorical',
+        'b': 'boolean',
+        'M': 'datetime',
+    }
 
     @staticmethod
     def get_transformers_by_type():
@@ -85,9 +100,10 @@ class HyperTransformer:
                 input_type = transformer.get_input_type()
                 transformers_for_type = data_type_transformers.get(input_type, [])
                 transformers_for_type.append(transformer)
-                data_type_transformers.update({input_type, transformers_for_type})
-            except:
+                data_type_transformers.update({input_type: transformers_for_type})
+            except AttributeError:
                 pass
+        return data_type_transformers
 
     def __init__(self, transformers=None, copy=True, dtypes=None, dtype_transformers=None):
         self.transformers = transformers

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -73,14 +73,6 @@ class HyperTransformer:
         'b': 'boolean',
         'M': 'datetime',
     }
-    DEFAULT_TRANSFORMERS = {
-        'numerical': NumericalTransformer,
-        'integer': NumericalTransformer(dtype=int),
-        'float': NumericalTransformer(dtype=float),
-        'categorical': CategoricalTransformer(fuzzy=True),
-        'boolean': BooleanTransformer,
-        'datetime': DatetimeTransformer,
-    }
     _DTYPES_TO_DATA_TYPES = {
         'i': 'integer',
         'f': 'float',

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -1,8 +1,6 @@
 """Hyper transformer module."""
 
-import inspect
 import re
-import sys
 from copy import deepcopy
 
 import numpy as np
@@ -90,27 +88,6 @@ class HyperTransformer:
         'b': 'boolean',
         'M': 'datetime',
     }
-
-    @staticmethod
-    def get_transformers_by_type():
-        """Build a ``dict`` mapping data types to valid existing transformers for that type.
-
-        Returns:
-                dict:
-                    Mapping of data types to a list of existing transformers that take that
-                    type as an input.
-        """
-        data_type_transformers = {}
-        transformer_classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
-        for (_, transformer) in transformer_classes:
-            try:
-                input_type = transformer.get_input_type()
-                transformers_for_type = data_type_transformers.get(input_type, [])
-                transformers_for_type.append(transformer)
-                data_type_transformers.update({input_type: transformers_for_type})
-            except AttributeError:
-                pass
-        return data_type_transformers
 
     def __init__(self, transformers=None, copy=True, dtypes=None, dtype_transformers=None):
         self.transformers = transformers

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -131,7 +131,7 @@ def get_default_transformers():
 
 @lru_cache()
 def get_default_transformer(data_type):
-    """Gets default transformer for a data type.
+    """Get default transformer for a data type.
 
     Returns:
         Transformer:

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -25,6 +25,14 @@ TRANSFORMERS = {
     transformer.__name__: transformer
     for transformer in BaseTransformer.__subclasses__()
 }
+DEFAULT_TRANSFORMERS = {
+    'numerical': NumericalTransformer,
+    'integer': NumericalTransformer(dtype=int),
+    'float': NumericalTransformer(dtype=float),
+    'categorical': CategoricalTransformer(fuzzy=True),
+    'boolean': BooleanTransformer,
+    'datetime': DatetimeTransformer,
+}
 
 
 def load_transformer(transformer):
@@ -99,3 +107,21 @@ def get_transformers_by_type():
             pass
 
     return data_type_transformers
+
+
+def get_default_transformers():
+    """Build a ``dict`` mapping data types to a default transformer for that type.
+
+    Returns:
+            dict:
+                Mapping of data types to a transformer.
+    """
+    transformers_by_type = get_transformers_by_type()
+    defaults = {}
+    for (data_type, transformers) in transformers_by_type.items():
+        if data_type in DEFAULT_TRANSFORMERS:
+            defaults[data_type] = DEFAULT_TRANSFORMERS[data_type]
+        else:
+            defaults[data_type] = transformers[0]
+
+    return defaults

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -1,6 +1,7 @@
 """Transformers module."""
 
 from collections import defaultdict
+
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BooleanTransformer
 from rdt.transformers.categorical import (

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -77,3 +77,25 @@ def load_transformers(transformers):
         name: load_transformer(transformer)
         for name, transformer in transformers.items()
     }
+
+
+def get_transformers_by_type():
+    """Build a ``dict`` mapping data types to valid existing transformers for that type.
+
+    Returns:
+            dict:
+                Mapping of data types to a list of existing transformers that take that
+                type as an input.
+    """
+    data_type_transformers = {}
+    transformer_classes = BaseTransformer.get_subclasses()
+    for transformer in transformer_classes:
+        try:
+            input_type = transformer.get_input_type()
+            transformers_for_type = data_type_transformers.get(input_type, [])
+            transformers_for_type.append(transformer)
+            data_type_transformers.update({input_type: transformers_for_type})
+        except AttributeError:
+            pass
+
+    return data_type_transformers

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -1,5 +1,6 @@
 """Transformers module."""
 
+from collections import defaultdict
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BooleanTransformer
 from rdt.transformers.categorical import (
@@ -23,7 +24,7 @@ __all__ = [
 
 TRANSFORMERS = {
     transformer.__name__: transformer
-    for transformer in BaseTransformer.__subclasses__()
+    for transformer in BaseTransformer.get_subclasses()
 }
 DEFAULT_TRANSFORMERS = {
     'numerical': NumericalTransformer,
@@ -95,14 +96,12 @@ def get_transformers_by_type():
                 Mapping of data types to a list of existing transformers that take that
                 type as an input.
     """
-    data_type_transformers = {}
+    data_type_transformers = defaultdict(list)
     transformer_classes = BaseTransformer.get_subclasses()
     for transformer in transformer_classes:
         try:
             input_type = transformer.get_input_type()
-            transformers_for_type = data_type_transformers.get(input_type, [])
-            transformers_for_type.append(transformer)
-            data_type_transformers.update({input_type: transformers_for_type})
+            data_type_transformers[input_type].append(transformer)
         except AttributeError:
             pass
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -1,6 +1,7 @@
 """Transformers module."""
 
 from collections import defaultdict
+from functools import lru_cache
 
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BooleanTransformer
@@ -93,9 +94,9 @@ def get_transformers_by_type():
     """Build a ``dict`` mapping data types to valid existing transformers for that type.
 
     Returns:
-            dict:
-                Mapping of data types to a list of existing transformers that take that
-                type as an input.
+        dict:
+            Mapping of data types to a list of existing transformers that take that
+            type as an input.
     """
     data_type_transformers = defaultdict(list)
     transformer_classes = BaseTransformer.get_subclasses()
@@ -109,12 +110,13 @@ def get_transformers_by_type():
     return data_type_transformers
 
 
+@lru_cache()
 def get_default_transformers():
     """Build a ``dict`` mapping data types to a default transformer for that type.
 
     Returns:
-            dict:
-                Mapping of data types to a transformer.
+        dict:
+            Mapping of data types to a transformer.
     """
     transformers_by_type = get_transformers_by_type()
     defaults = {}
@@ -125,3 +127,15 @@ def get_default_transformers():
             defaults[data_type] = transformers[0]
 
     return defaults
+
+
+@lru_cache()
+def get_default_transformer(data_type):
+    """Gets default transformer for a data type.
+
+    Returns:
+        Transformer:
+            Default transformer for data type.
+    """
+    default_transformers = get_default_transformers()
+    return default_transformers[data_type]

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -33,6 +33,7 @@ class BaseTransformer:
         for subclass in cls.__subclasses__():
             if abc.ABC not in subclass.__bases__:
                 subclasses.append(subclass)
+
             subclasses += subclass.get_subclasses()
 
         return subclasses

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -1,4 +1,5 @@
 """BaseTransformer module."""
+import abc
 
 
 class BaseTransformer:
@@ -19,6 +20,22 @@ class BaseTransformer:
     _columns = None
     _column_prefix = None
     _output_columns = None
+
+    @classmethod
+    def get_subclasses(cls):
+        """Recursively find subclasses of this Baseline.
+
+        Returns:
+            list:
+                List of all subclasses of this class.
+        """
+        subclasses = []
+        for subclass in cls.__subclasses__():
+            if abc.ABC not in subclass.__bases__:
+                subclasses.append(subclass)
+            subclasses += subclass.get_subclasses()
+
+        return subclasses
 
     @classmethod
     def get_input_type(cls):


### PR DESCRIPTION
resolves #232 

This PR adds the following attributes to the `HyperTransformer`

1. `_DTYPES_TO_DATA_TYPES` - a dict mapping the pandas dtypes to an RDT data type
2. `DEFAULT_TRANSFORMERS` - a dict mapping the RDT data types to a default transformer

It also adds the following static method
1. `get_transformers_by_type` - a function that loops through all existing transformers and creates a dict mapping data types to a list of valid transformers for that type.

