### PR TITLE
Add gaussian copula to init

### DIFF
--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -18,12 +18,25 @@ __all__ = [
     'NullTransformer',
     'OneHotEncodingTransformer',
     'LabelEncodingTransformer',
+    'GaussianCopulaTransformer',
 ]
+
+
+def _get_transformer_subclasses(base):
+    subclasses = base.__subclasses__()
+
+    if len(subclasses) == 0:
+        return []
+
+    for subclass in subclasses:
+        subclasses.extend(_get_transformer_subclasses(subclass))
+
+    return subclasses
 
 
 TRANSFORMERS = {
     transformer.__name__: transformer
-    for transformer in BaseTransformer.__subclasses__()
+    for transformer in _get_transformer_subclasses(BaseTransformer)
 }
 
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -7,6 +7,7 @@ from rdt.transformers.categorical import (
 from rdt.transformers.datetime import DatetimeTransformer
 from rdt.transformers.null import NullTransformer
 from rdt.transformers.numerical import GaussianCopulaTransformer, NumericalTransformer
+from rdt.transformers.utils import get_subclasses
 
 __all__ = [
     'BaseTransformer',
@@ -22,21 +23,9 @@ __all__ = [
 ]
 
 
-def _get_transformer_subclasses(base):
-    subclasses = base.__subclasses__()
-
-    if len(subclasses) == 0:
-        return []
-
-    for subclass in subclasses:
-        subclasses.extend(_get_transformer_subclasses(subclass))
-
-    return subclasses
-
-
 TRANSFORMERS = {
     transformer.__name__: transformer
-    for transformer in _get_transformer_subclasses(BaseTransformer)
+    for transformer in get_subclasses(BaseTransformer)
 }
 
 

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -1,0 +1,14 @@
+"""Utils for transformers."""
+
+
+def get_subclasses(base):
+    """Get all subclasses of a base class."""
+    subclasses = base.__subclasses__()
+
+    if len(subclasses) == 0:
+        return []
+
+    for subclass in subclasses:
+        subclasses.extend(get_subclasses(subclass))
+
+    return subclasses

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -1,0 +1,26 @@
+from rdt.transformers.utils import get_subclasses
+
+
+class TestBaseClass:
+    pass
+
+
+class TestChildClass(TestBaseClass):
+    pass
+
+
+class TestSecondChildClass(TestChildClass):
+    pass
+
+
+def test_get_subclasses():
+    """Test the `utils.get_subclasses` method.
+
+    Expect that get_subclasses returns all the subclasses
+    of a class, and the subclasses of its subclasses.
+    """
+    subclasses = get_subclasses(TestBaseClass)
+
+    assert len(subclasses) == 2
+    assert TestChildClass in subclasses
+    assert TestSecondChildClass in subclasses


### PR DESCRIPTION
Currently, `GaussianCopulaTransformer` isn't in the list of rdt `TRANSFORMERS`, because we only get the immediate subclasses of the `BaseTransformer`. Since `GaussianCopulaTransformer` is a subclass of the `NumericalTransformer`, it isn't included. This was causing issues when I tried to call `load_transformer` on the `GaussianCopulaTransformer`.

In order to get all transformers, we could recursively get the subclasses of the `BaseTransformer`.