### PR TITLE
Update the return dtype of boolean transformer

### DIFF
--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -85,4 +85,9 @@ class BooleanTransformer(BaseTransformer):
 
             data = pd.Series(data)
 
-        return np.round(data).clip(0, 1).astype('boolean').astype('object')
+        try:
+            out = np.round(data).clip(0, 1).astype('boolean').astype('bool')
+        except ValueError:
+            out = np.round(data).clip(0, 1).astype('boolean').astype('object')
+
+        return out

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -33,7 +33,6 @@ def get_input_data_without_nan():
         'names': ['Jon', 'Arya', 'Jon', 'Jon'],
     })
     data['datetime'] = pd.to_datetime(data['datetime'])
-    data['bool'] = data['bool'].astype('O')  # boolean transformer returns O instead of bool
 
     return data
 


### PR DESCRIPTION
In the BooleanTransformer, we always cast the reverse transformed data to type `object`, because if a boolean series contains NaNs, it will be type `object`. However, if the input is a boolean series without NaNs (therefore type `bool`), the output type will be inconsistent.

We could instead try to first cast the output type to `bool`, and if there is a `ValueError` due to the presence of NaNs, we could cast it to `object`. The alternative is to first check if the series has any null values, but we have previously seen that checking for nulls is not very performant.