### PR TITLE
Add flake8 addons that pass on our code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
-extend-ignore = D107, SFS2, SFS3
+extend-ignore = D107
 
 [isort]
 line_length = 99

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,9 @@ universal = 1
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 extend-ignore = D107
+per-file-ignores =
+    tests/performance/profiling.py:T001
+    tests/performance/test_performance.py:T001
 
 [isort]
 line_length = 99

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,16 @@ development_requires = [
     # style check
     'flake8>=3.7.7,<4',
     'flake8-absolute-import>=1.0,<2',
+    'flake8-builtins>=1.5.3,<1.6',
+    'flake8-comprehensions>=3.6.1,<3.7',
+    'flake8-debugger>=4.0.0,<4.1',
     'flake8-docstrings>=1.5.0,<2',
-    'flake8-sfs>=0.0.3,<0.1',
+    'flake8-mock>=0.3,<0.4',
+    'flake8-variables-names>=0.0.4,<0.1',
+    'dlint>=0.11.0,<0.12',  # code security addon for flake8
+    'flake8-fixme>=1.1.1,<1.2',
+    'flake8-eradicate>=1.1.0,<1.2',
+    'flake8-mutable>=1.2.0,<1.3',
     'isort>=4.3.4,<5',
     'pylint>=2.5.3,<3',
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ development_requires = [
     'flake8-fixme>=1.1.1,<1.2',
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-mutable>=1.2.0,<1.3',
+    'flake8-print>=4.0.0,<4.1',
     'isort>=4.3.4,<5',
     'pylint>=2.5.3,<3',
 


### PR DESCRIPTION
As part of #248 , we are adding the following list of addons to `flake8` that already are satisfied by our code:

* `flake8-builtins` - Check for python builtins being used as variables or parameters.
* `flake8-comprehensions` - Helps you write better list/set/dict comprehensions.
* `flake8-debugger` - Debug statement checker.
* `flake8-print` - Check for print statements in python files.
* `flake8-variables-names` - Extension that helps to make more readable variables names.
* `Dlint` - Tool for encouraging best coding practices and helping ensure Python code is secure.
* `flake8-mock` - Provides checking mock non-existent methods.
* `flake8-fixme` - Check for FIXME, TODO and other temporary developer notes.
* `flake8-eradicate` - Plugin to find commented out or dead code.
* `flake8-mutable` - Extension for mutable default arguments.

