### PR TITLE
Add flake8-pytest-style

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ development_requires = [
     'flake8-sfs>=0.0.3,<0.1',
     'isort>=4.3.4,<5',
     'pylint>=2.5.3,<3',
+    'flake8-pytest-style>=1.5.0,<1.6',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -219,7 +219,7 @@ def test_single_category():
     pd.testing.assert_frame_equal(data, reverse)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail()
 def test_dtype_category():
     df = pd.DataFrame({'a': ['a', 'b', 'c']}, dtype='category')
 

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -18,8 +18,8 @@ class TestHyperTransformer(TestCase):
         ht = HyperTransformer()
 
         # Asserts
-        self.assertTrue(ht.copy)
-        self.assertEqual(ht.dtypes, None)
+        assert ht.copy
+        assert ht.dtypes is None
 
     def test__analyze(self):
         """Test _analyze"""
@@ -59,7 +59,8 @@ class TestHyperTransformer(TestCase):
             'int': [1, 2, None],
             'complex': [1.0 + 0j, 2.0 + 1j, None],
         })
-        with pytest.raises(ValueError):
+
+        with pytest.raises(ValueError, match='Unsupported dtype: complex'):
             hp._analyze(data)
 
     def test_fit_with_analyze(self):
@@ -93,9 +94,9 @@ class TestHyperTransformer(TestCase):
         expect_float_call_count = 1
         expect_bool_call_count = 1
 
-        self.assertEqual(int_mock.fit.call_count, expect_int_call_count)
-        self.assertEqual(float_mock.fit.call_count, expect_float_call_count)
-        self.assertEqual(bool_mock.fit.call_count, expect_bool_call_count)
+        assert int_mock.fit.call_count == expect_int_call_count
+        assert float_mock.fit.call_count == expect_float_call_count
+        assert bool_mock.fit.call_count == expect_bool_call_count
 
     def test_fit_transform(self):
         """Test call fit_transform"""
@@ -110,19 +111,13 @@ class TestHyperTransformer(TestCase):
         expect_call_args_fit = pd.DataFrame()
         expect_call_args_transform = pd.DataFrame()
 
-        self.assertEqual(
-            transformer.fit.call_count,
-            expect_call_count_fit
-        )
+        assert transformer.fit.call_count == expect_call_count_fit
         pd.testing.assert_frame_equal(
             transformer.fit.call_args[0][0],
             expect_call_args_fit
         )
 
-        self.assertEqual(
-            transformer.transform.call_count,
-            expect_call_count_transform
-        )
+        assert transformer.transform.call_count == expect_call_count_transform
         pd.testing.assert_frame_equal(
             transformer.transform.call_args[0][0],
             expect_call_args_transform

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -15,8 +15,8 @@ class TestBooleanTransformer(TestCase):
         transformer = BooleanTransformer()
 
         # Asserts
-        self.assertEqual(transformer.nan, -1, "Unexpected nan")
-        self.assertIsNone(transformer.null_column, "null_column is None by default")
+        assert transformer.nan == -1
+        assert transformer.null_column is None
 
     def test__fit_nan_ignore(self):
         """Test _fit nan equal to ignore"""
@@ -28,13 +28,7 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        expect_fill_value = None
-
-        self.assertEqual(
-            transformer.null_transformer.fill_value,
-            expect_fill_value,
-            "Unexpected fill value"
-        )
+        assert transformer.null_transformer.fill_value is None
 
     def test__fit_nan_not_ignore(self):
         """Test _fit nan not equal to ignore"""
@@ -46,13 +40,7 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        expect_fill_value = 0
-
-        self.assertEqual(
-            transformer.null_transformer.fill_value,
-            expect_fill_value,
-            "Unexpected fill value"
-        )
+        assert transformer.null_transformer.fill_value == 0
 
     def test__fit_array(self):
         """Test _fit with numpy.array"""
@@ -64,13 +52,7 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        expect_fill_value = 0
-
-        self.assertEqual(
-            transformer.null_transformer.fill_value,
-            expect_fill_value,
-            "Unexpected fill value"
-        )
+        assert transformer.null_transformer.fill_value == 0
 
     def test__transform_series(self):
         """Test transform pandas.Series"""
@@ -86,11 +68,7 @@ class TestBooleanTransformer(TestCase):
         expect_call_count = 1
         expect_call_args = pd.Series([0., 1., None, 1., 0.], dtype=float)
 
-        self.assertEqual(
-            transformer.null_transformer.transform.call_count,
-            expect_call_count,
-            "NullTransformer.transform must be called one time"
-        )
+        assert transformer.null_transformer.transform.call_count == expect_call_count
         pd.testing.assert_series_equal(
             transformer.null_transformer.transform.call_args[0][0],
             expect_call_args
@@ -110,11 +88,7 @@ class TestBooleanTransformer(TestCase):
         expect_call_count = 1
         expect_call_args = pd.Series([0., 1., None, 1., 0.], dtype=float)
 
-        self.assertEqual(
-            transformer.null_transformer.transform.call_count,
-            expect_call_count,
-            "NullTransformer.transform must be called one time"
-        )
+        assert transformer.null_transformer.transform.call_count == expect_call_count
         pd.testing.assert_series_equal(
             transformer.null_transformer.transform.call_args[0][0],
             expect_call_args
@@ -136,11 +110,7 @@ class TestBooleanTransformer(TestCase):
         expect_call_count = 0
 
         np.testing.assert_equal(result, expect)
-        self.assertEqual(
-            transformer.null_transformer.reverse_transform.call_count,
-            expect_call_count,
-            "NullTransformer.reverse_transform should not be called when nan is ignore"
-        )
+        assert transformer.null_transformer.reverse_transform.call_count == expect_call_count
 
     def test__reverse_transform_nan_not_ignore(self):
         """Test _reverse_transform with nan not equal to ignore"""
@@ -160,11 +130,7 @@ class TestBooleanTransformer(TestCase):
         expect_call_count = 1
 
         np.testing.assert_equal(result, expect)
-        self.assertEqual(
-            transformer.null_transformer.reverse_transform.call_count,
-            expect_call_count,
-            "NullTransformer.reverse_transform should not be called when nan is ignore"
-        )
+        assert transformer.null_transformer.reverse_transform.call_count == expect_call_count
 
     def test__reverse_transform_not_null_values(self):
         """Test _reverse_transform not null values correctly"""

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -479,7 +479,7 @@ class TestOneHotEncodingTransformer:
         data = [[], [], []]
 
         # Assert
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Unexpected format.'):
             ohet._prepare_data(data)
 
     def test__prepare_data_nested_lists(self):
@@ -488,7 +488,7 @@ class TestOneHotEncodingTransformer:
         data = [[[]]]
 
         # Assert
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Unexpected format.'):
             ohet._prepare_data(data)
 
     def test__prepare_data_list_of_lists(self):

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -16,8 +16,8 @@ class TestNullTransformer(TestCase):
         transformer = NullTransformer(None)
 
         # Asserts
-        self.assertIsNone(transformer.null_column, "null_column is None by default")
-        self.assertFalse(transformer.copy, "copy is False by default")
+        transformer.null_column is None
+        assert not transformer.copy
 
     def test_fit_fill_value_mean(self):
         """If fill_value is mean, _fill_value is the mean of the input data."""


### PR DESCRIPTION
As part of #248 , add `flake8-pytest-style` and adapt the current code to pass this lint.