### PR TITLE
Improve integration tests

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -145,7 +145,9 @@ class HyperTransformer:
 
         for field in data:
             if field not in provided_fields:
-                self.field_types[field] = self._DTYPES_TO_DATA_TYPES[data[field].dtype.kind]
+                clean_data = data[field].dropna()
+                kind = clean_data.infer_objects().dtype.kind
+                self.field_types[field] = self._DTYPES_TO_DATA_TYPES[kind]
 
     def _get_next_transformer(self, output_field, output_type, next_transformers):
         next_transformer = None

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -134,7 +134,6 @@ def get_transformed_data():
     }, index=index)
 
 
-
 DETERMINISTIC_CATEGORICAL = deepcopy(DEFAULT_TRANSFORMERS)
 DETERMINISTIC_CATEGORICAL['categorical'] = CategoricalTransformer
 

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -157,16 +157,16 @@ def test_hypertransformer_default_inputs():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
-    # setup
+    # Setup
     data = get_input_data()
 
-    # run
+    # Run
     ht = HyperTransformer()
     ht.fit(data)
     transformed = ht.transform(data)
     reverse_transformed = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     expected_transformed = get_transformed_data()
     pd.testing.assert_frame_equal(transformed, expected_transformed)
 
@@ -194,7 +194,7 @@ def test_hypertransformer_field_transformers():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
-    # setup
+    # Setup
     field_transformers = {
         'integer': NumericalTransformer(dtype=np.int64),
         'float': NumericalTransformer(dtype=float),
@@ -206,13 +206,13 @@ def test_hypertransformer_field_transformers():
     }
     data = get_input_data()
 
-    # run
+    # Run
     ht = HyperTransformer(field_transformers=field_transformers)
     ht.fit(data)
     transformed = ht.transform(data)
     reverse_transformed = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     expected_transformed = get_transformed_data()
     del expected_transformed['datetime.is_null']
     rename = {'datetime.value': 'datetime.value.value'}
@@ -250,7 +250,7 @@ def test_hypertransformer_field_transformers_multi_column_fields():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
-    # setup
+    # Setup
     data = pd.DataFrame({
         'year': [2001, 2002, 2003],
         'month': [1, 2, 3],
@@ -280,20 +280,20 @@ def test_hypertransformer_field_transformers_multi_column_fields():
     })
     expected_reversed = data.copy()
 
-    # run
+    # Run
     ht = HyperTransformer(field_transformers=field_transformers)
     ht.fit(data)
     transformed = ht.transform(data)
     reverse_transformed = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     pd.testing.assert_frame_equal(transformed, expected_transformed)
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
 def test_single_category():
     """Test that categorical variables with a single value are supported."""
-    # setup
+    # Setup
     ht = HyperTransformer(field_transformers={
         'a': OneHotEncodingTransformer()
     })
@@ -301,27 +301,27 @@ def test_single_category():
         'a': ['a', 'a', 'a']
     })
 
-    # run
+    # Run
     ht.fit(data)
     transformed = ht.transform(data)
     reverse = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     pd.testing.assert_frame_equal(data, reverse)
 
 
 def test_dtype_category():
     """Test that categorical variables of dtype category are supported."""
-    # setup
+    # Setup
     data = pd.DataFrame({'a': ['a', 'b', 'c']}, dtype='category')
 
-    # run
+    # Run
     ht = HyperTransformer()
     ht.fit(data)
     transformed = ht.transform(data)
     reverse = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     pd.testing.assert_frame_equal(reverse, data)
 
 
@@ -330,35 +330,35 @@ def test_subset_of_columns_nan_data():
 
     See https://github.com/sdv-dev/RDT/issues/152
     """
-    # setup
+    # Setup
     data = get_input_data()
     subset = data[[data.columns[0]]].copy()
     ht = HyperTransformer()
     ht.fit(data)
 
-    # run
+    # Run
     transformed = ht.transform(subset)
     reverse = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     pd.testing.assert_frame_equal(subset, reverse)
 
 
 def test_with_unfitted_columns():
     """HyperTransform should be able to transform even if there are unseen columns in data."""
-    # setup
+    # Setup
     data = get_input_data()
     ht = HyperTransformer(data_type_transformers={'categorical': CategoricalTransformer})
     ht.fit(data)
 
-    # run
+    # Run
     new_data = get_input_data()
     new_column = pd.Series([4, 5, 6, 7, 8, 9])
     new_data['z'] = new_column
     transformed = ht.transform(new_data)
     reverse = ht.reverse_transform(transformed)
 
-    # assert
+    # Assert
     expected_reversed = get_input_data()
     expected_reversed['z'] = new_column
     expected_reversed = expected_reversed.reindex(

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -1,13 +1,15 @@
-import random
+"""Integration tests for the HyperTransformer."""
+
+from copy import deepcopy
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from rdt import HyperTransformer
 from rdt.transformers import (
-    BaseTransformer, BooleanTransformer, CategoricalTransformer, NumericalTransformer,
-    OneHotEncodingTransformer)
+    DEFAULT_TRANSFORMERS, BaseTransformer, BooleanTransformer, CategoricalTransformer,
+    NumericalTransformer, OneHotEncodingTransformer)
 
 
 class DummyTransformerNumerical(BaseTransformer):
@@ -84,44 +86,43 @@ class DummyTransformerMultiColumn(BaseTransformer):
 
 
 def get_input_data_with_nan():
+    index = [4, 6, 3, 8, 'a']
+    datetimes = pd.to_datetime([np.nan, '2010-02-01', '2010-01-01', '2010-02-01', '2010-01-01'])
     data = pd.DataFrame({
         'integer': [1, 2, 1, 3, 1],
         'float': [0.1, 0.2, 0.1, np.nan, 0.1],
         'categorical': ['a', 'a', np.nan, 'b', 'a'],
         'bool': [False, np.nan, False, True, False],
-        'datetime': [
-            np.nan, '2010-02-01', '2010-01-01', '2010-02-01', '2010-01-01'
-        ],
+        'datetime': datetimes,
         'names': ['Jon', 'Arya', 'Arya', 'Jon', 'Jon'],
-    })
-    data['datetime'] = pd.to_datetime(data['datetime'])
+    }, index=index)
 
     return data
 
 
-def get_input_data_without_nan(index=None):
+def get_input_data_without_nan():
+    index = [4, 6, 3, 'a']
+    datetimes = pd.to_datetime(['2010-02-01', '2010-01-01', '2010-02-01', '2010-02-01'])
     data = pd.DataFrame({
         'integer': [1, 2, 1, 3],
         'float': [0.1, 0.2, 0.1, 0.1],
         'categorical': ['a', 'a', 'b', 'a'],
         'bool': [False, False, True, False],
-        'datetime': ['2010-02-01', '2010-01-01', '2010-02-01', '2010-02-01'],
+        'datetime': datetimes,
         'names': ['Jon', 'Arya', 'Jon', 'Jon'],
-    })
-    data['datetime'] = pd.to_datetime(data['datetime'])
-    if index:
-        data.index = index
+    }, index=index)
 
     return data
 
 
-def get_reversed(index=None):
-    reverse_transformed = get_input_data_without_nan(index)
+def get_reversed():
+    reverse_transformed = get_input_data_without_nan()
     reverse_transformed['bool'] = reverse_transformed['bool'].astype('O')
     return reverse_transformed
 
 
-def get_transformed_data(index=None):
+def get_transformed_data():
+    index = [4, 6, 3, 'a']
     transformed = pd.DataFrame({
         'integer.value': [1, 2, 1, 3],
         'float.value': [0.1, 0.2, 0.1, 0.1],
@@ -134,59 +135,32 @@ def get_transformed_data(index=None):
             1.2649824e+18
         ],
         'names.value': [0.375, 0.875, 0.375, 0.375]
-    })
-    if index:
-        transformed.index = index
+    }, index=index)
 
     return transformed
 
 
-def get_transformed_nan_data():
+def get_transformed_data_with_nan():
+    index = [4, 6, 3, 8, 'a']
+    datetimes = [1.2636432e+18, 1.2649824e+18, 1.262304e+18, 1.2649824e+18, 1.262304e+18]
     return pd.DataFrame({
-        'integer': [1, 2, 1, 3, 1],
-        'float': [0.1, 0.2, 0.1, 0.125, 0.1],
-        'float#1': [0.0, 0.0, 0.0, 1.0, 0.0],
-        'categorical': [0.3, 0.3, 0.9, 0.7, 0.3],
-        'bool': [0.0, -1.0, 0.0, 1.0, 0.0],
-        'bool#1': [0.0, 1.0, 0.0, 0.0, 0.0],
-        'datetime': [
-            1.2636432e+18, 1.2649824e+18, 1.262304e+18,
-            1.2649824e+18, 1.262304e+18
-        ],
-        'datetime#1': [1.0, 0.0, 0.0, 0.0, 0.0],
-        'names': [0.3, 0.8, 0.8, 0.3, 0.3],
-    })
+        'integer.value': [1, 2, 1, 3, 1],
+        'float.value': [0.1, 0.2, 0.1, 0.125, 0.1],
+        'float.is_null': [0.0, 0.0, 0.0, 1.0, 0.0],
+        'categorical.value': [0.3, 0.3, 0.9, 0.7, 0.3],
+        'bool.value': [0.0, -1.0, 0.0, 1.0, 0.0],
+        'bool.is_null': [0.0, 1.0, 0.0, 0.0, 0.0],
+        'datetime.value': datetimes,
+        'datetime.is_null': [1.0, 0.0, 0.0, 0.0, 0.0],
+        'names.value': [0.3, 0.8, 0.8, 0.3, 0.3],
+    }, index=index)
 
 
-def get_transformers():
-    return {
-        'integer': {
-            'class': 'NumericalTransformer',
-            'kwargs': {
-                'dtype': np.int64,
-            }
-        },
-        'float': {
-            'class': 'NumericalTransformer',
-            'kwargs': {
-                'dtype': np.float64,
-            }
-        },
-        'categorical': {
-            'class': 'CategoricalTransformer'
-        },
-        'bool': {
-            'class': 'BooleanTransformer'
-        },
-        'datetime': {
-            'class': 'DatetimeTransformer'
-        },
-        'names': {
-            'class': 'CategoricalTransformer',
-        },
-    }
+DETERMINISTIC_CATEGORICAL = deepcopy(DEFAULT_TRANSFORMERS)
+DETERMINISTIC_CATEGORICAL['categorical'] = CategoricalTransformer
 
 
+@patch('rdt.transformers.DEFAULT_TRANSFORMERS', DETERMINISTIC_CATEGORICAL)
 def test_hypertransformer_default_inputs():
     """Test the HyperTransformer with default parameters.
 
@@ -195,8 +169,8 @@ def test_hypertransformer_default_inputs():
     transformers to use for each field.
 
     Setup:
-        - `data_type_transformers` will be set to use the `CategoricalTransformer`
-        for categorical data types so that the output is predictable.
+        - Patch the DEFAULT_TRANSFORMERS to use the `CategoricalTransformer`
+        for categorical data types, so that the output is predictable.
 
     Input:
         - A dataframe with every data type.
@@ -205,27 +179,20 @@ def test_hypertransformer_default_inputs():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
-    index = random.shuffle(list(range(4)))
-    data = get_input_data_without_nan(index)
-    expected_transformed = data.drop('datetime', axis=1)
-    expected_transformed.columns = [
-        'integer.value',
-        'float.value',
-        'categorical.value',
-        'bool.value',
-        'names.value'
-    ]
-    expected_transformed = get_transformed_data(index)
-    expected_reversed = get_reversed(index)
+    # setup
+    data = get_input_data_with_nan()
 
-    ht = HyperTransformer(data_type_transformers={'categorical': CategoricalTransformer})
+    # run
+    ht = HyperTransformer()
     ht.fit(data)
     transformed = ht.transform(data)
-
-    pd.testing.assert_frame_equal(transformed, expected_transformed)
-
     reverse_transformed = ht.reverse_transform(transformed)
 
+    # assert
+    expected_transformed = get_transformed_data_with_nan()
+    pd.testing.assert_frame_equal(transformed, expected_transformed)
+
+    expected_reversed = get_input_data_with_nan()
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
@@ -238,7 +205,7 @@ def test_hypertransformer_field_transformers():
     till it is.
 
     Setup:
-        - The datetime column is set to use a dumm transformer that stringifies
+        - The datetime column is set to use a dummy transformer that stringifies
         the input. That output is then set to use the categorical transformer.
 
     Input:
@@ -249,6 +216,7 @@ def test_hypertransformer_field_transformers():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
+    # setup
     field_transformers = {
         'integer': NumericalTransformer(dtype=np.int64),
         'float': NumericalTransformer(dtype=float),
@@ -258,23 +226,23 @@ def test_hypertransformer_field_transformers():
         'datetime.value': CategoricalTransformer,
         'names': CategoricalTransformer
     }
-    data = get_input_data_without_nan()
-    expected_transformed = get_transformed_data().rename(
-        columns={'datetime.value': 'datetime.value.value'})
-    expected_transformed['datetime.value.value'] = [0.375, 0.875, 0.375, 0.375]
-    expected_reversed = get_reversed()
+    data = get_input_data_with_nan()
 
+    # run
     ht = HyperTransformer(field_transformers=field_transformers)
     ht.fit(data)
     transformed = ht.transform(data)
-
-    pd.testing.assert_frame_equal(
-        transformed,
-        expected_transformed
-    )
-
     reverse_transformed = ht.reverse_transform(transformed)
 
+    # assert
+    expected_transformed = get_transformed_data_with_nan()
+    del expected_transformed['datetime.is_null']
+    rename = {'datetime.value': 'datetime.value.value'}
+    expected_transformed = expected_transformed.rename(columns=rename)
+    expected_transformed['datetime.value.value'] = [0.9, 0.6, 0.2, 0.6, 0.2]
+    pd.testing.assert_frame_equal(transformed, expected_transformed)
+
+    expected_reversed = get_input_data_with_nan()
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
@@ -303,6 +271,7 @@ def test_hypertransformer_field_transformers_multi_column_fields():
         - The transformed data should contain all the ML ready data.
         - The reverse transformed data should be the same as the input.
     """
+    # setup
     data = pd.DataFrame({
         'year': [2001, 2002, 2003],
         'month': [1, 2, 3],
@@ -332,21 +301,20 @@ def test_hypertransformer_field_transformers_multi_column_fields():
     })
     expected_reversed = data.copy()
 
+    # run
     ht = HyperTransformer(field_transformers=field_transformers)
     ht.fit(data)
     transformed = ht.transform(data)
-
-    pd.testing.assert_frame_equal(
-        transformed,
-        expected_transformed
-    )
-
     reverse_transformed = ht.reverse_transform(transformed)
 
+    # assert
+    pd.testing.assert_frame_equal(transformed, expected_transformed)
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
 def test_single_category():
+    """Test that categorical variables with a single value are supported."""
+    # setup
     ht = HyperTransformer(field_transformers={
         'a': OneHotEncodingTransformer()
     })
@@ -354,63 +322,28 @@ def test_single_category():
         'a': ['a', 'a', 'a']
     })
 
+    # run
     ht.fit(data)
     transformed = ht.transform(data)
-
     reverse = ht.reverse_transform(transformed)
 
+    # assert
     pd.testing.assert_frame_equal(data, reverse)
 
 
-@pytest.mark.xfail()
 def test_dtype_category():
+    """Test that categorical variables of dtype category are supported."""
+    # setup
     data = pd.DataFrame({'a': ['a', 'b', 'c']}, dtype='category')
 
+    # run
     ht = HyperTransformer()
     ht.fit(data)
-
-    trans = ht.transform(data)
-
-    rever = ht.reverse_transform(trans)
-
-    pd.testing.assert_frame_equal(rever, data)
-
-
-def test_subset_of_columns():
-    """HyperTransform should be able to transform a subset of the training columns.
-
-    See https://github.com/sdv-dev/RDT/issues/152
-    """
-    data = get_input_data_without_nan()
-
-    ht = HyperTransformer()
-    ht.fit(data)
-
-    subset = get_input_data_without_nan()[[data.columns[0]]]
-    transformed = ht.transform(subset)
+    transformed = ht.transform(data)
     reverse = ht.reverse_transform(transformed)
 
-    pd.testing.assert_frame_equal(subset, reverse)
-
-
-def test_with_unfitted_columns():
-    """HyperTransform should be able to transform even if there are unseen columns in data."""
-    data = get_input_data_without_nan()
-
-    ht = HyperTransformer(data_type_transformers={'categorical': CategoricalTransformer})
-    ht.fit(data)
-
-    new_data = get_input_data_without_nan()
-    new_column = pd.Series([6, 7, 8, 9])
-    new_data['z'] = new_column
-    transformed = ht.transform(new_data)
-    reverse = ht.reverse_transform(transformed)
-
-    expected_reversed = get_reversed()
-    expected_reversed['z'] = new_column
-    expected_reversed = expected_reversed.reindex(
-        columns=['z', 'integer', 'float', 'categorical', 'bool', 'datetime', 'names'])
-    pd.testing.assert_frame_equal(expected_reversed, reverse)
+    # assert
+    pd.testing.assert_frame_equal(reverse, data)
 
 
 def test_subset_of_columns_nan_data():
@@ -418,13 +351,37 @@ def test_subset_of_columns_nan_data():
 
     See https://github.com/sdv-dev/RDT/issues/152
     """
+    # setup
     data = get_input_data_with_nan()
-
     ht = HyperTransformer()
     ht.fit(data)
 
+    # run
     subset = get_reversed()[[data.columns[0]]]
     transformed = ht.transform(subset)
     reverse = ht.reverse_transform(transformed)
 
+    # assert
     pd.testing.assert_frame_equal(subset, reverse)
+
+
+def test_with_unfitted_columns():
+    """HyperTransform should be able to transform even if there are unseen columns in data."""
+    # setup
+    data = get_input_data_without_nan()
+    ht = HyperTransformer(data_type_transformers={'categorical': CategoricalTransformer})
+    ht.fit(data)
+
+    # run
+    new_data = get_input_data_without_nan()
+    new_column = pd.Series([6, 7, 8, 9])
+    new_data['z'] = new_column
+    transformed = ht.transform(new_data)
+    reverse = ht.reverse_transform(transformed)
+
+    # assert
+    expected_reversed = get_reversed()
+    expected_reversed['z'] = new_column
+    expected_reversed = expected_reversed.reindex(
+        columns=['z', 'integer', 'float', 'categorical', 'bool', 'datetime', 'names'])
+    pd.testing.assert_frame_equal(expected_reversed, reverse)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -85,8 +85,10 @@ class DummyTransformerMultiColumn(BaseTransformer):
         return out
 
 
+TEST_DATA_INDEX = [4, 6, 3, 8, 'a', 1.0, 2.0, 3.0]
+
+
 def get_input_data():
-    index = [4, 6, 3, 8, 'a', 1.0, 2.0, 3.0]
     datetimes = pd.to_datetime([
         np.nan,
         '2010-02-01',
@@ -104,13 +106,12 @@ def get_input_data():
         'bool': [False, np.nan, False, True, False, True, True, False],
         'datetime': datetimes,
         'names': ['Jon', 'Arya', 'Arya', 'Jon', 'Jon', 'Sansa', 'Jon', 'Jon'],
-    }, index=index)
+    }, index=TEST_DATA_INDEX)
 
     return data
 
 
 def get_transformed_data():
-    index = [4, 6, 3, 8, 'a', 1.0, 2.0, 3.0]
     datetimes = [
         1.263069e+18,
         1.264982e+18,
@@ -131,7 +132,7 @@ def get_transformed_data():
         'datetime.value': datetimes,
         'datetime.is_null': [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         'names.value': [0.3125, 0.75, 0.75, 0.3125, 0.3125, 0.9375, 0.3125, 0.3125]
-    }, index=index)
+    }, index=TEST_DATA_INDEX)
 
 
 DETERMINISTIC_CATEGORICAL = deepcopy(DEFAULT_TRANSFORMERS)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -135,11 +135,11 @@ def get_transformed_data():
     }, index=TEST_DATA_INDEX)
 
 
-DETERMINISTIC_CATEGORICAL = deepcopy(DEFAULT_TRANSFORMERS)
-DETERMINISTIC_CATEGORICAL['categorical'] = CategoricalTransformer
+DETERMINISTIC_DEFAULT_TRANSFORMERS = deepcopy(DEFAULT_TRANSFORMERS)
+DETERMINISTIC_DEFAULT_TRANSFORMERS['categorical'] = CategoricalTransformer
 
 
-@patch('rdt.transformers.DEFAULT_TRANSFORMERS', DETERMINISTIC_CATEGORICAL)
+@patch('rdt.transformers.DEFAULT_TRANSFORMERS', DETERMINISTIC_DEFAULT_TRANSFORMERS)
 def test_hypertransformer_default_inputs():
     """Test the HyperTransformer with default parameters.
 

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -85,75 +85,54 @@ class DummyTransformerMultiColumn(BaseTransformer):
         return out
 
 
-def get_input_data_with_nan():
-    index = [4, 6, 3, 8, 'a']
-    datetimes = pd.to_datetime([np.nan, '2010-02-01', '2010-01-01', '2010-02-01', '2010-01-01'])
+def get_input_data():
+    index = [4, 6, 3, 8, 'a', 1.0, 2.0, 3.0]
+    datetimes = pd.to_datetime([
+        np.nan,
+        '2010-02-01',
+        '2010-01-01',
+        '2010-01-01',
+        '2010-01-01',
+        '2010-02-01',
+        '2010-01-01',
+        '2010-01-01',
+    ])
     data = pd.DataFrame({
-        'integer': [1, 2, 1, 3, 1],
-        'float': [0.1, 0.2, 0.1, np.nan, 0.1],
-        'categorical': ['a', 'a', np.nan, 'b', 'a'],
-        'bool': [False, np.nan, False, True, False],
+        'integer': [1, 2, 1, 3, 1, 4, 2, 3],
+        'float': [0.1, 0.2, 0.1, np.nan, 0.1, 0.4, np.nan, 0.3],
+        'categorical': ['a', 'a', np.nan, 'b', 'a', 'b', 'a', 'a'],
+        'bool': [False, np.nan, False, True, False, True, True, False],
         'datetime': datetimes,
-        'names': ['Jon', 'Arya', 'Arya', 'Jon', 'Jon'],
+        'names': ['Jon', 'Arya', 'Arya', 'Jon', 'Jon', 'Sansa', 'Jon', 'Jon'],
     }, index=index)
 
     return data
-
-
-def get_input_data_without_nan():
-    index = [4, 6, 3, 'a']
-    datetimes = pd.to_datetime(['2010-02-01', '2010-01-01', '2010-02-01', '2010-02-01'])
-    data = pd.DataFrame({
-        'integer': [1, 2, 1, 3],
-        'float': [0.1, 0.2, 0.1, 0.1],
-        'categorical': ['a', 'a', 'b', 'a'],
-        'bool': [False, False, True, False],
-        'datetime': datetimes,
-        'names': ['Jon', 'Arya', 'Jon', 'Jon'],
-    }, index=index)
-
-    return data
-
-
-def get_reversed():
-    reverse_transformed = get_input_data_without_nan()
-    reverse_transformed['bool'] = reverse_transformed['bool'].astype('O')
-    return reverse_transformed
 
 
 def get_transformed_data():
-    index = [4, 6, 3, 'a']
-    transformed = pd.DataFrame({
-        'integer.value': [1, 2, 1, 3],
-        'float.value': [0.1, 0.2, 0.1, 0.1],
-        'categorical.value': [0.375, 0.375, 0.875, 0.375],
-        'bool.value': [0.0, 0.0, 1.0, 0.0],
-        'datetime.value': [
-            1.2649824e+18,
-            1.262304e+18,
-            1.2649824e+18,
-            1.2649824e+18
-        ],
-        'names.value': [0.375, 0.875, 0.375, 0.375]
-    }, index=index)
-
-    return transformed
-
-
-def get_transformed_data_with_nan():
-    index = [4, 6, 3, 8, 'a']
-    datetimes = [1.2636432e+18, 1.2649824e+18, 1.262304e+18, 1.2649824e+18, 1.262304e+18]
+    index = [4, 6, 3, 8, 'a', 1.0, 2.0, 3.0]
+    datetimes = [
+        1.263069e+18,
+        1.264982e+18,
+        1.262304e+18,
+        1.262304e+18,
+        1.262304e+18,
+        1.264982e+18,
+        1.262304e+18,
+        1.262304e+18
+    ]
     return pd.DataFrame({
-        'integer.value': [1, 2, 1, 3, 1],
-        'float.value': [0.1, 0.2, 0.1, 0.125, 0.1],
-        'float.is_null': [0.0, 0.0, 0.0, 1.0, 0.0],
-        'categorical.value': [0.3, 0.3, 0.9, 0.7, 0.3],
-        'bool.value': [0.0, -1.0, 0.0, 1.0, 0.0],
-        'bool.is_null': [0.0, 1.0, 0.0, 0.0, 0.0],
+        'integer.value': [1, 2, 1, 3, 1, 4, 2, 3],
+        'float.value': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
+        'float.is_null': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+        'categorical.value': [0.3125, 0.3125, 0.9375, 0.75, 0.3125, 0.75, 0.3125, 0.3125],
+        'bool.value': [0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+        'bool.is_null': [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         'datetime.value': datetimes,
-        'datetime.is_null': [1.0, 0.0, 0.0, 0.0, 0.0],
-        'names.value': [0.3, 0.8, 0.8, 0.3, 0.3],
+        'datetime.is_null': [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        'names.value': [0.3125, 0.75, 0.75, 0.3125, 0.3125, 0.9375, 0.3125, 0.3125]
     }, index=index)
+
 
 
 DETERMINISTIC_CATEGORICAL = deepcopy(DEFAULT_TRANSFORMERS)
@@ -180,7 +159,7 @@ def test_hypertransformer_default_inputs():
         - The reverse transformed data should be the same as the input.
     """
     # setup
-    data = get_input_data_with_nan()
+    data = get_input_data()
 
     # run
     ht = HyperTransformer()
@@ -189,10 +168,10 @@ def test_hypertransformer_default_inputs():
     reverse_transformed = ht.reverse_transform(transformed)
 
     # assert
-    expected_transformed = get_transformed_data_with_nan()
+    expected_transformed = get_transformed_data()
     pd.testing.assert_frame_equal(transformed, expected_transformed)
 
-    expected_reversed = get_input_data_with_nan()
+    expected_reversed = get_input_data()
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
@@ -226,7 +205,7 @@ def test_hypertransformer_field_transformers():
         'datetime.value': CategoricalTransformer,
         'names': CategoricalTransformer
     }
-    data = get_input_data_with_nan()
+    data = get_input_data()
 
     # run
     ht = HyperTransformer(field_transformers=field_transformers)
@@ -235,14 +214,15 @@ def test_hypertransformer_field_transformers():
     reverse_transformed = ht.reverse_transform(transformed)
 
     # assert
-    expected_transformed = get_transformed_data_with_nan()
+    expected_transformed = get_transformed_data()
     del expected_transformed['datetime.is_null']
     rename = {'datetime.value': 'datetime.value.value'}
     expected_transformed = expected_transformed.rename(columns=rename)
-    expected_transformed['datetime.value.value'] = [0.9, 0.6, 0.2, 0.6, 0.2]
+    transformed_datetimes = [0.9375, 0.75, 0.3125, 0.3125, 0.3125, 0.75, 0.3125, 0.3125]
+    expected_transformed['datetime.value.value'] = transformed_datetimes
     pd.testing.assert_frame_equal(transformed, expected_transformed)
 
-    expected_reversed = get_input_data_with_nan()
+    expected_reversed = get_input_data()
     pd.testing.assert_frame_equal(expected_reversed, reverse_transformed)
 
 
@@ -352,12 +332,12 @@ def test_subset_of_columns_nan_data():
     See https://github.com/sdv-dev/RDT/issues/152
     """
     # setup
-    data = get_input_data_with_nan()
+    data = get_input_data()
+    subset = data[[data.columns[0]]].copy()
     ht = HyperTransformer()
     ht.fit(data)
 
     # run
-    subset = get_reversed()[[data.columns[0]]]
     transformed = ht.transform(subset)
     reverse = ht.reverse_transform(transformed)
 
@@ -368,19 +348,19 @@ def test_subset_of_columns_nan_data():
 def test_with_unfitted_columns():
     """HyperTransform should be able to transform even if there are unseen columns in data."""
     # setup
-    data = get_input_data_without_nan()
+    data = get_input_data()
     ht = HyperTransformer(data_type_transformers={'categorical': CategoricalTransformer})
     ht.fit(data)
 
     # run
-    new_data = get_input_data_without_nan()
-    new_column = pd.Series([6, 7, 8, 9])
+    new_data = get_input_data()
+    new_column = pd.Series([4, 5, 6, 7, 8, 9])
     new_data['z'] = new_column
     transformed = ht.transform(new_data)
     reverse = ht.reverse_transform(transformed)
 
     # assert
-    expected_reversed = get_reversed()
+    expected_reversed = get_input_data()
     expected_reversed['z'] = new_column
     expected_reversed = expected_reversed.reindex(
         columns=['z', 'integer', 'float', 'categorical', 'bool', 'datetime', 'names'])

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -255,10 +256,10 @@ class TestHyperTransformer(TestCase):
         # Setup
         ht = HyperTransformer(field_types={'a': 'numerical', 'b': 'categorical'})
         data = pd.DataFrame({
-            'a': [1, 2, 3],
-            'b': ['category1', 'category2', 'category3'],
-            'c': [True, False, True],
-            'd': [1.0, 2.0, 3.0]
+            'a': [np.nan, 1, 2, 3],
+            'b': [np.nan, 'category1', 'category2', 'category3'],
+            'c': [np.nan, True, False, True],
+            'd': [np.nan, 1.0, 2.0, 3.0]
         })
 
         # Run


### PR DESCRIPTION
Fix a problem on the `HyperTransformer` type detection when being passed a `bool` column with `nan` values, which was incorrectly being labeled as `categorical`.

Also re-organize and clean up a bit the HyperTransformer integration tests.