### PR TITLE
Issue 304 DeprecationWarning of `np.float` and `np.int`

### DIFF
--- a/tests/datasets/categorical.py
+++ b/tests/datasets/categorical.py
@@ -49,7 +49,7 @@ class RandomIntegerNaNsGenerator(CategoricalGenerator):
     @staticmethod
     def generate(num_rows):
         """Generate a ``num_rows`` number of rows."""
-        return add_nans(RandomIntegerGenerator.generate(num_rows).astype(np.float))
+        return add_nans(RandomIntegerGenerator.generate(num_rows).astype(float))
 
     @staticmethod
     def get_performance_thresholds():
@@ -238,7 +238,7 @@ class SingleIntegerNaNsGenerator(CategoricalGenerator):
     @staticmethod
     def generate(num_rows):
         """Generate a ``num_rows`` number of rows."""
-        return add_nans(SingleIntegerGenerator.generate(num_rows).astype(np.float))
+        return add_nans(SingleIntegerGenerator.generate(num_rows).astype(float))
 
     @staticmethod
     def get_performance_thresholds():

--- a/tests/datasets/numerical.py
+++ b/tests/datasets/numerical.py
@@ -48,7 +48,7 @@ class RandomIntegerNaNsGenerator(NumericalGenerator):
     @staticmethod
     def generate(num_rows):
         """Generate a ``num_rows`` number of rows."""
-        return add_nans(RandomIntegerGenerator.generate(num_rows).astype(np.float))
+        return add_nans(RandomIntegerGenerator.generate(num_rows).astype(float))
 
     @staticmethod
     def get_performance_thresholds():
@@ -104,7 +104,7 @@ class ConstantIntegerNaNsGenerator(NumericalGenerator):
     @staticmethod
     def generate(num_rows):
         """Generate a ``num_rows`` number of rows."""
-        return add_nans(ConstantIntegerGenerator.generate(num_rows).astype(np.float))
+        return add_nans(ConstantIntegerGenerator.generate(num_rows).astype(float))
 
     @staticmethod
     def get_performance_thresholds():
@@ -165,7 +165,7 @@ class AlmostConstantIntegerNaNsGenerator(NumericalGenerator):
         """Generate a ``num_rows`` number of rows."""
         ii32 = np.iinfo(np.int32)
         values = np.random.randint(ii32.min, ii32.max, size=2)
-        additional_values = np.full(num_rows - 2, values[1]).astype(np.float)
+        additional_values = np.full(num_rows - 2, values[1]).astype(float)
         array = np.concatenate([values, add_nans(additional_values)])
         np.random.shuffle(array)
         return array

--- a/tests/datasets/tests/test_categorical.py
+++ b/tests/datasets/tests/test_categorical.py
@@ -9,7 +9,7 @@ class TestRandomIntegerGenerator:
     def test(self):
         output = categorical.RandomIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) < 6
         assert np.isnan(output).sum() == 0
 
@@ -19,7 +19,7 @@ class TestRandomIntegerNaNsGenerator:
     def test(self):
         output = categorical.RandomIntegerNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) < 7
         assert np.isnan(output).sum() > 0
 
@@ -67,7 +67,7 @@ class TestSingleIntegerGenerator:
     def test(self):
         output = categorical.SingleIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) == 1
         assert np.isnan(output).sum() == 0
 
@@ -77,7 +77,7 @@ class TestSingleIntegerNaNsGenerator:
     def test(self):
         output = categorical.SingleIntegerNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 2
         assert np.isnan(output).sum() >= 1
 
@@ -107,7 +107,7 @@ class TestUniqueIntegerGenerator:
     def test(self):
         output = categorical.UniqueIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) == 10
         assert np.isnan(output).sum() == 0
 
@@ -119,7 +119,7 @@ class TestUniqueIntegerNaNsGenerator:
         nulls = np.isnan(output).sum()
 
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 10 - nulls + 1
         assert nulls > 0
 

--- a/tests/datasets/tests/test_numerical.py
+++ b/tests/datasets/tests/test_numerical.py
@@ -9,7 +9,7 @@ class TestRandomIntegerGenerator:
     def test(self):
         output = numerical.RandomIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) > 1
         assert np.isnan(output).sum() == 0
 
@@ -19,7 +19,7 @@ class TestRandomIntegerNaNsGenerator:
     def test(self):
         output = numerical.RandomIntegerNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) > 1
         assert np.isnan(output).sum() > 0
 
@@ -29,7 +29,7 @@ class TestConstantIntegerGenerator:
     def test(self):
         output = numerical.ConstantIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) == 1
         assert np.isnan(output).sum() == 0
 
@@ -39,7 +39,7 @@ class TestConstantIntegerNaNsGenerator:
     def test(self):
         output = numerical.ConstantIntegerNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 2
         assert np.isnan(output).sum() >= 1
 
@@ -49,7 +49,7 @@ class TestAlmostConstantIntegerGenerator:
     def test(self):
         output = numerical.AlmostConstantIntegerGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.int
+        assert output.dtype == int
         assert len(pd.unique(output)) == 2
         assert np.isnan(output).sum() == 0
 
@@ -59,7 +59,7 @@ class TestAlmostConstantIntegerNaNsGenerator:
     def test(self):
         output = numerical.AlmostConstantIntegerNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 3
         assert np.isnan(output).sum() >= 1
 
@@ -69,7 +69,7 @@ class TestNormalGenerator:
     def test(self):
         output = numerical.NormalGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 10
         assert np.isnan(output).sum() == 0
 
@@ -79,7 +79,7 @@ class TestNormalNaNsGenerator:
     def test(self):
         output = numerical.NormalNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert 1 < len(pd.unique(output)) <= 10
         assert np.isnan(output).sum() >= 1
 
@@ -89,7 +89,7 @@ class TestBigNormalGenerator:
     def test(self):
         output = numerical.BigNormalGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert len(pd.unique(output)) == 10
         assert np.isnan(output).sum() == 0
 
@@ -99,6 +99,6 @@ class TestBigNormalNaNsGenerator:
     def test(self):
         output = numerical.BigNormalNaNsGenerator.generate(10)
         assert len(output) == 10
-        assert output.dtype == np.float
+        assert output.dtype == float
         assert 1 < len(pd.unique(output)) <= 10
         assert np.isnan(output).sum() >= 1

--- a/tests/datasets/tests/test_utils.py
+++ b/tests/datasets/tests/test_utils.py
@@ -18,7 +18,7 @@ def test_add_nulls_int():
 
 
 def test_add_nulls_float():
-    array = np.arange(100).astype(np.float)
+    array = np.arange(100).astype(float)
 
     with_nans = utils.add_nans(array)
 

--- a/tests/datasets/utils.py
+++ b/tests/datasets/utils.py
@@ -15,7 +15,7 @@ def add_nans(array):
             The same array with some values replaced by NaNs.
     """
     if array.dtype.kind == 'i':
-        array = array.astype(np.float)
+        array = array.astype(float)
 
     length = len(array)
     num_nulls = np.random.randint(1, length)

--- a/tests/integration/transformers/test_base.py
+++ b/tests/integration/transformers/test_base.py
@@ -39,7 +39,7 @@ def test_dummy_transformer_series_output():
             pass
 
         def _transform(self, data):
-            return data.astype(np.float)
+            return data.astype(float)
 
         def _reverse_transform(self, data):
             return data.round() != 0
@@ -101,8 +101,8 @@ def test_dummy_transformer_dataframe_output():
             out = pd.DataFrame(dict(zip(
                 self.output_columns,
                 [
-                    data.astype(np.float).fillna(-1),
-                    data.isna().astype(np.float)
+                    data.astype(float).fillna(-1),
+                    data.isna().astype(float)
                 ]
             )))
 
@@ -173,8 +173,8 @@ def test_dummy_transformer_multi_column_input():
             # Convert multiple columns into a single datetime
             data = pd.to_datetime(data)
 
-            float_data = data.to_numpy().astype(np.float64)
-            data_is_nan = data.isna().to_numpy().astype(np.float64)
+            float_data = data.to_numpy().astype(float)
+            data_is_nan = data.isna().to_numpy().astype(float)
 
             output = dict(zip(
                 self.output_columns,

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -27,12 +27,12 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([1.5, None, 2.5], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan')
+        transformer = NumericalTransformer(dtype=float, nan='nan')
         transformer._fit(data)
 
         # Asserts
         expect_fill_value = 'nan'
-        expect_dtype = np.float
+        expect_dtype = float
 
         assert transformer.null_transformer.fill_value == expect_fill_value
         assert transformer._dtype == expect_dtype
@@ -140,7 +140,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([1.5, None, 2.5], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding=None)
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding=None)
         transformer._fit(data)
 
         # Asserts
@@ -164,7 +164,7 @@ class TestNumericalTransformer(TestCase):
         expected_digits = 3
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding=expected_digits)
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding=expected_digits)
         transformer._fit(data)
 
         # Asserts
@@ -187,7 +187,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([1, 2.1, 3.12, 4.123, 5.1234, 6.123, 7.12, 8.1, 9], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -212,7 +212,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame(big_numbers, columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -238,7 +238,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([0.000000000000001], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -262,7 +262,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([15000, 4000, 60000, np.inf], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -284,7 +284,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([0, 0, 0], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -307,7 +307,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([-500, -220, -10], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan', rounding='auto')
+        transformer = NumericalTransformer(dtype=float, nan='nan', rounding='auto')
         transformer._fit(data)
 
         # Asserts
@@ -329,7 +329,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([1.5, None, 2.5], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan',
+        transformer = NumericalTransformer(dtype=float, nan='nan',
                                            min_value=None, max_value=None)
         transformer._fit(data)
 
@@ -352,7 +352,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([1.5, None, 2.5], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan',
+        transformer = NumericalTransformer(dtype=float, nan='nan',
                                            min_value=1, max_value=10)
         transformer._fit(data)
 
@@ -376,7 +376,7 @@ class TestNumericalTransformer(TestCase):
         data = pd.DataFrame([-100, -5000, 0, None, 100, 4000], columns=['a'])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan',
+        transformer = NumericalTransformer(dtype=float, nan='nan',
                                            min_value='auto', max_value='auto')
         transformer._fit(data)
 
@@ -398,7 +398,7 @@ class TestNumericalTransformer(TestCase):
         data = np.random.random(10)
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._rounding_digits = None
         result = transformer._reverse_transform(data)
 
@@ -454,7 +454,7 @@ class TestNumericalTransformer(TestCase):
         null_transformer.reverse_transform.return_value = np.array([0., 1.2, np.nan, 6.789])
         transformer.null_transformer = null_transformer
         transformer._rounding_digits = None
-        transformer._dtype = np.float
+        transformer._dtype = float
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -487,7 +487,7 @@ class TestNumericalTransformer(TestCase):
         null_transformer.reverse_transform.return_value = np.array([0., 1.2, np.nan, 6.789])
         transformer.null_transformer = null_transformer
         transformer._rounding_digits = None
-        transformer._dtype = np.int
+        transformer._dtype = int
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -510,7 +510,7 @@ class TestNumericalTransformer(TestCase):
         data = np.array([1.1111, 2.2222, 3.3333, 4.44444, 5.555555])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._rounding_digits = 2
         result = transformer._reverse_transform(data)
 
@@ -535,15 +535,15 @@ class TestNumericalTransformer(TestCase):
         data = np.array([2000.0, 120.0, 3100.0, 40100.0])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.int, nan=None)
-        transformer._dtype = np.int
+        transformer = NumericalTransformer(dtype=int, nan=None)
+        transformer._dtype = int
         transformer._rounding_digits = -3
         result = transformer._reverse_transform(data)
 
         # Assert
         expected_data = np.array([2000, 0, 3000, 40000])
         np.testing.assert_array_equal(result, expected_data)
-        assert result.dtype == np.int
+        assert result.dtype == int
 
     def test__reverse_transform_rounding_negative_rounding_float(self):
         """Test ``_reverse_transform`` when ``rounding`` is a negative int
@@ -562,14 +562,14 @@ class TestNumericalTransformer(TestCase):
         data = np.array([2000.0, 120.0, 3100.0, 40100.0])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._rounding_digits = -3
         result = transformer._reverse_transform(data)
 
         # Assert
         expected_data = np.array([2000.0, 0.0, 3000.0, 40000.0])
         np.testing.assert_array_equal(result, expected_data)
-        assert result.dtype == np.float
+        assert result.dtype == float
 
     def test__reverse_transform_rounding_zero(self):
         """Test ``_reverse_transform`` when ``rounding`` is a negative int
@@ -587,7 +587,7 @@ class TestNumericalTransformer(TestCase):
         data = np.array([2000.554, 120.2, 3101, 4010])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._rounding_digits = 0
         result = transformer._reverse_transform(data)
 
@@ -610,7 +610,7 @@ class TestNumericalTransformer(TestCase):
         data = np.array([-np.inf, -5000, -301, -250, 0, 125, 400, np.inf])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._min_value = -300
         result = transformer._reverse_transform(data)
 
@@ -633,7 +633,7 @@ class TestNumericalTransformer(TestCase):
         data = np.array([-np.inf, -5000, -301, -250, 0, 125, 401, np.inf])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._max_value = 400
         result = transformer._reverse_transform(data)
 
@@ -656,7 +656,7 @@ class TestNumericalTransformer(TestCase):
         data = np.array([-np.inf, -5000, -301, -250, 0, 125, 401, np.inf])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan=None)
+        transformer = NumericalTransformer(dtype=float, nan=None)
         transformer._max_value = 400
         transformer._min_value = -300
         result = transformer._reverse_transform(data)
@@ -700,7 +700,7 @@ class TestNumericalTransformer(TestCase):
         expected_data = np.array([-300, -300, np.nan, -250, 0, np.nan, 400, 400])
 
         # Run
-        transformer = NumericalTransformer(dtype=np.float, nan='nan')
+        transformer = NumericalTransformer(dtype=float, nan='nan')
         transformer._max_value = 400
         transformer._min_value = -300
         transformer.null_transformer = Mock()


### PR DESCRIPTION
Resolve #304 

Change `np.float` to `float` (or `np.float64`), and `np.int` to `int`