### PR TITLE
Fix bug due to `pandas` release

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -89,6 +89,7 @@ class CategoricalTransformer(BaseTransformer):
             dict:
                 intervals for each categorical value (start, end).
         """
+        data = data.fillna(np.nan)
         frequencies = data.value_counts(dropna=False)
 
         start = 0

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -156,7 +156,7 @@ class TestCategoricalTransformer:
             categorical value (start, end).
         """
         # Setup
-        data = pd.Series(['foo', np.nan, None, 'foo', 'foo', 'tar'])
+        data = pd.Series(['foo', np.nan, np.nan, 'foo', 'foo', 'tar'])
 
         # Run
         result = CategoricalTransformer._get_intervals(data)

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -156,7 +156,7 @@ class TestCategoricalTransformer:
             categorical value (start, end).
         """
         # Setup
-        data = pd.Series(['foo', np.nan, np.nan, 'foo', 'foo', 'tar'])
+        data = pd.Series(['foo', np.nan, None, 'foo', 'foo', 'tar'])
 
         # Run
         result = CategoricalTransformer._get_intervals(data)


### PR DESCRIPTION
Resolves #358 by converting all null-like values to `np.nan` in the `_get_intervals` method.