### PR TITLE
Update NullTransformer to make it user friendly

### DIFF
--- a/rdt/performance/performance.py
+++ b/rdt/performance/performance.py
@@ -86,7 +86,6 @@ def evaluate_transformer_performance(transformer, dataset_generator, verbose=Fal
         pandas.DataFrame:
             The performance test results.
     """
-
     transformer_args = TRANSFORMER_ARGS.get(transformer.__name__, {})
     transformer_instance = transformer(**transformer_args)
 

--- a/rdt/performance/performance.py
+++ b/rdt/performance/performance.py
@@ -9,6 +9,42 @@ from rdt.transformers import BaseTransformer
 
 DATASET_SIZES = [1000, 10000, 100000]
 
+# Additional arguments for transformers
+TRANSFORMER_ARGS = {
+    'BooleanTransformer': {
+        'missing_value_replacement': -1,
+        'model_missing_values': True
+    },
+    'DatetimeTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'DatetimeRoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalRoundedBoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalBoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'GaussianCopulaTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'BayesGMMTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+}
+
 
 def _get_dataset_sizes(data_type):
     """Get a list of (fit_size, transform_size) for each dataset generator.
@@ -50,7 +86,9 @@ def evaluate_transformer_performance(transformer, dataset_generator, verbose=Fal
         pandas.DataFrame:
             The performance test results.
     """
-    transformer_instance = transformer()
+
+    transformer_args = TRANSFORMER_ARGS.get(transformer.__name__, {})
+    transformer_instance = transformer(**transformer_args)
 
     sizes = _get_dataset_sizes(dataset_generator.DATA_TYPE)
 

--- a/rdt/performance/profiling.py
+++ b/rdt/performance/profiling.py
@@ -74,7 +74,6 @@ def profile_transformer(transformer, dataset_generator, transform_size, fit_size
     fit_dataset = pd.Series(dataset_generator.generate(fit_size))
     replace = transform_size > fit_size
     transform_dataset = fit_dataset.sample(transform_size, replace=replace)
-    transformer.columns = ['column']
 
     try:
         fit_time = _profile_time(transformer, 'fit', fit_dataset, copy=True)

--- a/rdt/performance/profiling.py
+++ b/rdt/performance/profiling.py
@@ -74,9 +74,10 @@ def profile_transformer(transformer, dataset_generator, transform_size, fit_size
     fit_dataset = pd.Series(dataset_generator.generate(fit_size))
     replace = transform_size > fit_size
     transform_dataset = fit_dataset.sample(transform_size, replace=replace)
+    transformer.columns = ['column']
 
     try:
-        fit_time = _profile_time(transformer, 'fit', fit_dataset, copy=True)
+        fit_time = _profile_time(transformer, 'fit', fit_dataset)
         fit_memory = _profile_memory(transformer.fit, fit_dataset)
         transformer.fit(fit_dataset)
 
@@ -88,7 +89,7 @@ def profile_transformer(transformer, dataset_generator, transform_size, fit_size
         reverse_memory = _profile_memory(transformer.reverse_transform, reverse_dataset)
     except TypeError:
         # temporarily support both old and new style transformers
-        fit_time = _profile_time(transformer, '_fit', fit_dataset, copy=True)
+        fit_time = _profile_time(transformer, '_fit', fit_dataset)
         fit_memory = _profile_memory(transformer._fit, fit_dataset)
         transformer._fit(fit_dataset)
 

--- a/rdt/performance/profiling.py
+++ b/rdt/performance/profiling.py
@@ -77,7 +77,7 @@ def profile_transformer(transformer, dataset_generator, transform_size, fit_size
     transformer.columns = ['column']
 
     try:
-        fit_time = _profile_time(transformer, 'fit', fit_dataset)
+        fit_time = _profile_time(transformer, 'fit', fit_dataset, copy=True)
         fit_memory = _profile_memory(transformer.fit, fit_dataset)
         transformer.fit(fit_dataset)
 
@@ -89,7 +89,7 @@ def profile_transformer(transformer, dataset_generator, transform_size, fit_size
         reverse_memory = _profile_memory(transformer.reverse_transform, reverse_dataset)
     except TypeError:
         # temporarily support both old and new style transformers
-        fit_time = _profile_time(transformer, '_fit', fit_dataset)
+        fit_time = _profile_time(transformer, '_fit', fit_dataset, copy=True)
         fit_memory = _profile_memory(transformer._fit, fit_dataset)
         transformer._fit(fit_dataset)
 

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -105,14 +105,14 @@ class BaseTransformer:
         """
         return self._add_prefix(self.NEXT_TRANSFORMERS)
 
-    def get_input_columns(self):
-        """Return list of input column names for transformer.
+    def get_input_column(self):
+        """Return input column name for transformer.
 
         Returns:
-            list:
-                Input column names.
+            str:
+                Input column name.
         """
-        return self.columns
+        return self.columns[0]
 
     def get_output_columns(self):
         """Return list of column names created in ``transform``.

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -47,7 +47,7 @@ class BooleanTransformer(BaseTransformer):
         output_types = {
             'value': 'float',
         }
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             output_types['is_null'] = 'float'
 
         return self._add_prefix(output_types)
@@ -63,7 +63,7 @@ class BooleanTransformer(BaseTransformer):
             self.missing_value_replacement,
             self.model_missing_values
         )
-        self.null_transformer.fit(data, self.get_input_column())
+        self.null_transformer.fit(data)
 
     def _transform(self, data):
         """Transform boolean to float.

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -16,15 +16,15 @@ class BooleanTransformer(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (int or None):
-            Replace null values with the given value. If ``None``, do not replace them.
-            Defaults to ``-1``.
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an object is given, replace them
+            with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
+            them with the corresponding aggregation. If ``None`` is given, do not replace them.
+            Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the fit data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            If ``True``, create the new column if there are null values.
+            If ``False``, do not create the new column. Defaults to ``False``.
     """
 
     INPUT_TYPE = 'boolean'

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -33,7 +33,7 @@ class BooleanTransformer(BaseTransformer):
 
     null_transformer = None
 
-    def __init__(self, missing_value_replacement=-1, model_missing_values=True):
+    def __init__(self, missing_value_replacement=None, model_missing_values=False):
         self.missing_value_replacement = missing_value_replacement
         self.model_missing_values = model_missing_values
 

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -18,8 +18,8 @@ class BooleanTransformer(BaseTransformer):
     Args:
         missing_value_replacement (object or None):
             Indicate what to do with the null values. If an object is given, replace them
-            with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
-            them with the corresponding aggregation. If ``None`` is given, do not replace them.
+            with the given value. If the string ``'mode'`` is given, replace them with the
+            most common value. If ``None`` is given, do not replace them.
             Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not. The column

--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -22,9 +22,10 @@ class BooleanTransformer(BaseTransformer):
             them with the corresponding aggregation. If ``None`` is given, do not replace them.
             Defaults to ``None``.
         model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``True``, create the new column if there are null values.
-            If ``False``, do not create the new column. Defaults to ``False``.
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
     """
 
     INPUT_TYPE = 'boolean'

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -167,9 +167,6 @@ class DatetimeTransformer(BaseTransformer):
         if self.strip_constant:
             data = data * self.divider
 
-        if not isinstance(data, pd.Series):
-            data = pd.Series(data)
-
         return pd.to_datetime(data)
 
 

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -21,9 +21,10 @@ class DatetimeTransformer(BaseTransformer):
             them with the corresponding aggregation. If ``None`` is given, do not replace them.
             Defaults to ``None``.
         model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``True``, create the new column if there are null values.
-            If ``False``, do not create the new column. Defaults to ``False``.
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
         strip_constant (bool):
             Whether to optimize the output values by finding the smallest time unit that
             is not zero on the training datetimes and dividing the generated numerical
@@ -182,17 +183,16 @@ class DatetimeRoundedTransformer(DatetimeTransformer):
     This class behaves exactly as the ``DatetimeTransformer`` with ``strip_constant=True``.
 
     Args:
-        missing_value_replacement (int, str or None):
-            Indicate what to do with the null values. If an integer is given, replace them
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an object is given, replace them
             with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
             them with the corresponding aggregation. If ``None`` is given, do not replace them.
-            Defaults to ``'mean'``.
-        model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
             Defaults to ``None``.
+        model_missing_values (bool):
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
     """
 
     def __init__(self, missing_value_replacement=None, model_missing_values=False):

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -59,7 +59,7 @@ class DatetimeTransformer(BaseTransformer):
             bool:
                 Whether or not transforming and then reverse transforming returns the input data.
         """
-        if self.null_transformer and not self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and not self.null_transformer.models_missing_values():
             return False
 
         return self.COMPOSITION_IS_IDENTITY
@@ -74,7 +74,7 @@ class DatetimeTransformer(BaseTransformer):
         output_types = {
             'value': 'float',
         }
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             output_types['is_null'] = 'float'
 
         return self._add_prefix(output_types)
@@ -129,7 +129,7 @@ class DatetimeTransformer(BaseTransformer):
             self.missing_value_replacement,
             self.model_missing_values
         )
-        self.null_transformer.fit(transformed, self.get_input_column())
+        self.null_transformer.fit(transformed)
 
     def _transform(self, data):
         """Transform datetime values to float values.

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -15,17 +15,15 @@ class DatetimeTransformer(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (int, str or None):
-            Indicate what to do with the null values. If an integer is given, replace them
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an object is given, replace them
             with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
             them with the corresponding aggregation. If ``None`` is given, do not replace them.
-            Defaults to ``'mean'``.
+            Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            If ``True``, create the new column if there are null values.
+            If ``False``, do not create the new column. Defaults to ``False``.
         strip_constant (bool):
             Whether to optimize the output values by finding the smallest time unit that
             is not zero on the training datetimes and dividing the generated numerical

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -167,6 +167,9 @@ class DatetimeTransformer(BaseTransformer):
         if self.strip_constant:
             data = data * self.divider
 
+        if not isinstance(data, pd.Series):
+            data = pd.Series(data)
+
         return pd.to_datetime(data)
 
 

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -45,7 +45,7 @@ class DatetimeTransformer(BaseTransformer):
     null_transformer = None
     divider = None
 
-    def __init__(self, missing_value_replacement='mean', model_missing_values=True,
+    def __init__(self, missing_value_replacement=None, model_missing_values=False,
                  strip_constant=False, datetime_format=None):
         self.missing_value_replacement = missing_value_replacement
         self.model_missing_values = model_missing_values
@@ -197,6 +197,6 @@ class DatetimeRoundedTransformer(DatetimeTransformer):
             Defaults to ``None``.
     """
 
-    def __init__(self, missing_value_replacement='mean', model_missing_values=True):
+    def __init__(self, missing_value_replacement=None, model_missing_values=False):
         super().__init__(missing_value_replacement=missing_value_replacement,
                          model_missing_values=model_missing_values, strip_constant=True)

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -1,54 +1,53 @@
 """Transformer for data that contains Null values."""
 
+import logging
 import warnings
 
 import numpy as np
 import pandas as pd
 
 IRREVERSIBLE_WARNING = (
-    'Replacing nulls with existing value without `null_column`, which is not reversible. '
-    'Use `null_column=True` to ensure that the transformation is reversible.'
+    'Replacing nulls with existing value without `model_missing_values`, which is not reversible. '
+    'Use `model_missing_values=True` to ensure that the transformation is reversible.'
 )
 
+LOGGER = logging.getLogger(__name__)
 
 class NullTransformer():
     """Transformer for data that contains Null values.
 
     Args:
-        fill_value (object or None):
+        missing_value_replacement (object or None):
             Value to replace nulls, or strategy to compute the value, which can
             be ``mean`` or ``mode``. If ``None`` is given, the ``mean`` or ``mode``
             strategy will be applied depending on whether the input data is numerical
             or not. Defaults to `None`.
-        null_column (bool):
+        model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
             If ``None``, only create a new column when the data contains null values.
             If ``True``, always create the new column whether there are null values or not.
             If ``False``, do not create the new column.
             Defaults to ``None``.
-        copy (bool):
-            Whether to create a copy of the input data or modify it destructively.
     """
 
     nulls = None
-    _null_column = None
-    _fill_value = None
+    _model_missing_values = None
+    _missing_value_replacement = None
 
-    def __init__(self, fill_value=None, null_column=None, copy=False):
-        self.fill_value = fill_value
-        self.null_column = null_column
-        self.copy = copy
+    def __init__(self, missing_value_replacement=None, model_missing_values=False):
+        self.missing_value_replacement = missing_value_replacement
+        self.model_missing_values = model_missing_values
 
-    def creates_null_column(self):
+    def creates_model_missing_values(self):
         """Indicate whether this transformer creates a null column on transform.
 
         Returns:
             bool:
                 Whether a null column is created on transform.
         """
-        return bool(self._null_column)
+        return bool(self._model_missing_values)
 
-    def _get_fill_value(self, data, null_values):
+    def _get_missing_value_replacement(self, data, null_values):
         """Get the fill value to use for the given data.
 
         Args:
@@ -62,26 +61,26 @@ class NullTransformer():
             object:
                 The fill value that needs to be used.
         """
-        fill_value = self.fill_value
+        missing_value_replacement = self.missing_value_replacement
 
-        if fill_value in (None, 'mean', 'mode') and null_values.all():
+        if missing_value_replacement in (None, 'mean', 'mode') and null_values.all():
             return 0
 
-        if fill_value is None:
+        if missing_value_replacement is None:
             if pd.api.types.is_numeric_dtype(data):
-                fill_value = 'mean'
+                missing_value_replacement = 'mean'
             else:
-                fill_value = 'mode'
+                missing_value_replacement = 'mode'
 
-        if fill_value == 'mean':
+        if missing_value_replacement == 'mean':
             return data.mean()
 
-        if fill_value == 'mode':
+        if missing_value_replacement == 'mode':
             return data.mode(dropna=True)[0]
 
-        return fill_value
+        return missing_value_replacement
 
-    def fit(self, data):
+    def fit(self, data, column):
         """Fit the transformer to the data.
 
         Evaluate if the transformer has to create the null column or not.
@@ -93,15 +92,19 @@ class NullTransformer():
         null_values = data.isna().to_numpy()
         self.nulls = null_values.any()
 
-        self._fill_value = self._get_fill_value(data, null_values)
+        self._missing_value_replacement = self._get_missing_value_replacement(data, null_values)
+        self._model_missing_values = self.model_missing_values
 
-        if self.null_column is None:
-            self._null_column = self.nulls
-        else:
-            self._null_column = self.null_column
+        if not self.nulls and self._model_missing_values:
+            self._model_missing_values = False
+            guidance_message = (
+                f'Guidance: There are no missing values in column {column}. '
+                'Extra column not created.'
+            )
+            LOGGER.info(guidance_message)
 
     def transform(self, data):
-        """Replace null values with the indicated fill_value.
+        """Replace null values with the indicated missing_value_replacement.
 
         If required, create the null indicator column.
 
@@ -114,15 +117,13 @@ class NullTransformer():
         """
         isna = data.isna()
         if isna.any():
-            if not self._null_column and self._fill_value in data.to_numpy():
+            if (not self._model_missing_values and
+                    self._missing_value_replacement in data.to_numpy()):
                 warnings.warn(IRREVERSIBLE_WARNING)
 
-            if not self.copy:
-                data[isna] = self._fill_value
-            else:
-                data = data.fillna(self._fill_value)
+            data = data.fillna(self._missing_value_replacement)
 
-        if self._null_column:
+        if self._model_missing_values:
             return pd.concat([data, isna.astype(np.float64)], axis=1).to_numpy()
 
         return data.to_numpy()
@@ -131,7 +132,7 @@ class NullTransformer():
         """Restore null values to the data.
 
         If a null indicator column was created during fit, use it as a reference.
-        Otherwise, replace all instances of ``fill_value`` that can be found in
+        Otherwise, replace all instances of ``missing_value_replacement`` that can be found in
         data.
 
         Args:
@@ -141,16 +142,14 @@ class NullTransformer():
         Returns:
             pandas.Series
         """
-        if self._null_column:
+        if self._model_missing_values:
             if self.nulls:
                 isna = data[:, 1] > 0.5
 
-            data = data[:, 0]
-            if self.copy:
-                data = data.copy()
+            data = data[:, 0].copy()
 
         elif self.nulls:
-            isna = self._fill_value == data
+            isna = self._missing_value_replacement == data
 
         data = pd.Series(data)
 

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -63,14 +63,8 @@ class NullTransformer():
         """
         missing_value_replacement = self.missing_value_replacement
 
-        if missing_value_replacement in (None, 'mean', 'mode') and null_values.all():
-            return 0
-
         if missing_value_replacement is None:
-            if pd.api.types.is_numeric_dtype(data):
-                missing_value_replacement = 'mean'
-            else:
-                missing_value_replacement = 'mode'
+            return np.nan
 
         if missing_value_replacement == 'mean':
             return data.mean()

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -20,24 +20,20 @@ class NullTransformer():
     Args:
         missing_value_replacement (object or None):
             Value to replace nulls, or strategy to compute the value, which can
-            be ``mean`` or ``mode``. If ``None`` is given, the ``mean`` or ``mode``
-            strategy will be applied depending on whether the input data is numerical
-            or not. Defaults to `None`.
+            be ``mean`` or ``mode``. If ``None`` is given the missing values will not be
+            replaced. Defaults to `None`.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            If ``True``, create the new column it there are null values.
+            If ``False``, do not create the new column. Defaults to ``False``.
     """
 
     nulls = None
     _model_missing_values = None
-    _missing_value_replacement = None
+    _missing_value_replacement = False
 
     def __init__(self, missing_value_replacement=None, model_missing_values=False):
         self.missing_value_replacement = missing_value_replacement
-        self.model_missing_values = model_missing_values
         self._model_missing_values = model_missing_values
 
     def models_missing_values(self):

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -40,7 +40,7 @@ class NullTransformer():
         self.model_missing_values = model_missing_values
         self._model_missing_values = model_missing_values
 
-    def creates_model_missing_values(self):
+    def models_missing_values(self):
         """Indicate whether this transformer creates a null column on transform.
 
         Returns:
@@ -73,7 +73,7 @@ class NullTransformer():
 
         return missing_value_replacement
 
-    def fit(self, data, column):
+    def fit(self, data):
         """Fit the transformer to the data.
 
         Evaluate if the transformer has to create the null column or not.
@@ -89,7 +89,7 @@ class NullTransformer():
         if not self.nulls and self._model_missing_values:
             self._model_missing_values = False
             guidance_message = (
-                f'Guidance: There are no missing values in column {column}. '
+                f'Guidance: There are no missing values in column {data.name}. '
                 'Extra column not created.'
             )
             LOGGER.info(guidance_message)

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -19,12 +19,13 @@ class NullTransformer():
 
     Args:
         missing_value_replacement (object or None):
-            Value to replace nulls, or strategy to compute the value, which can
-            be ``mean`` or ``mode``. If ``None`` is given the missing values will not be
-            replaced. Defaults to `None`.
+            Indicate what to do with the null values. If an integer, float or string is given,
+            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are given,
+            replace them with the corresponding aggregation (``'mean'`` only works for numerical
+            values). If ``None`` is given, do not replace them. Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
-            If ``True``, create the new column it there are null values.
+            If ``True``, create the new column if there are null values.
             If ``False``, do not create the new column. Defaults to ``False``.
     """
 

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -13,6 +13,7 @@ IRREVERSIBLE_WARNING = (
 
 LOGGER = logging.getLogger(__name__)
 
+
 class NullTransformer():
     """Transformer for data that contains Null values.
 
@@ -37,6 +38,7 @@ class NullTransformer():
     def __init__(self, missing_value_replacement=None, model_missing_values=False):
         self.missing_value_replacement = missing_value_replacement
         self.model_missing_values = model_missing_values
+        self._model_missing_values = model_missing_values
 
     def creates_model_missing_values(self):
         """Indicate whether this transformer creates a null column on transform.
@@ -47,15 +49,12 @@ class NullTransformer():
         """
         return bool(self._model_missing_values)
 
-    def _get_missing_value_replacement(self, data, null_values):
+    def _get_missing_value_replacement(self, data):
         """Get the fill value to use for the given data.
 
         Args:
             data (pd.Series):
                 The data that is being transformed.
-            null_values (np.array):
-                Array of boolean values that indicate which values in the
-                input data are nulls.
 
         Return:
             object:
@@ -86,9 +85,7 @@ class NullTransformer():
         null_values = data.isna().to_numpy()
         self.nulls = null_values.any()
 
-        self._missing_value_replacement = self._get_missing_value_replacement(data, null_values)
-        self._model_missing_values = self.model_missing_values
-
+        self._missing_value_replacement = self._get_missing_value_replacement(data)
         if not self.nulls and self._model_missing_values:
             self._model_missing_values = False
             guidance_message = (

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -86,7 +86,7 @@ class NumericalTransformer(BaseTransformer):
         output_types = {
             'value': 'float',
         }
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             output_types['is_null'] = 'float'
 
         return self._add_prefix(output_types)
@@ -98,7 +98,7 @@ class NumericalTransformer(BaseTransformer):
             bool:
                 Whether or not transforming and then reverse transforming returns the input data.
         """
-        if self.null_transformer and not self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and not self.null_transformer.models_missing_values():
             return False
 
         return self.COMPOSITION_IS_IDENTITY
@@ -145,7 +145,7 @@ class NumericalTransformer(BaseTransformer):
             self.missing_value_replacement,
             self.model_missing_values
         )
-        self.null_transformer.fit(data, self.get_input_column())
+        self.null_transformer.fit(data)
 
     def _transform(self, data):
         """Transform numerical data.
@@ -484,7 +484,7 @@ class BayesGMMTransformer(NumericalTransformer):
             'normalized': 'float',
             'component': 'categorical'
         }
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             output_types['is_null'] = 'float'
 
         return self._add_prefix(output_types)
@@ -548,7 +548,7 @@ class BayesGMMTransformer(NumericalTransformer):
         normalized = np.clip(normalized, -.99, .99)
         normalized = normalized[:, 0]
         rows = [normalized, selected_component]
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             rows.append(model_missing_values)
 
         return np.stack(rows, axis=1)  # noqa: PD013
@@ -579,7 +579,7 @@ class BayesGMMTransformer(NumericalTransformer):
             data = data.to_numpy()
 
         recovered_data = self._reverse_transform_helper(data)
-        if self.null_transformer and self.null_transformer.creates_model_missing_values():
+        if self.null_transformer and self.null_transformer.models_missing_values():
             data = np.stack([recovered_data, data[:, -1]], axis=1)  # noqa: PD013
         else:
             data = recovered_data

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -33,9 +33,10 @@ class NumericalTransformer(BaseTransformer):
             given, replace them with the corresponding aggregation. If ``None`` is given,
             do not replace them. Defaults to ``None``.
         model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``True``, create the new column if there are null values.
-            If ``False``, do not create the new column. Defaults to ``False``.
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
         rounding (int, str or None):
             Define rounding scheme for data. If set to an int, values will be rounded
             to that number of decimal places. If ``None``, values will not be rounded.
@@ -214,17 +215,16 @@ class GaussianCopulaTransformer(NumericalTransformer):
             Data type of the data to transform. It will be used when reversing the
             transformation. If not provided, the dtype of the fit data will be used.
             Defaults to ``None``.
-        missing_value_replacement (int, str or None):
-            Indicate what to do with the null values. If an integer is given, replace them
-            with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
-            them with the corresponding aggregation. If ``None`` is given, do not replace them.
-            Defaults to ``'mean'``.
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an integer or float is given,
+            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are
+            given, replace them with the corresponding aggregation. If ``None`` is given,
+            do not replace them. Defaults to ``None``.
         model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
         distribution (copulas.univariate.Univariate or str):
             Copulas univariate distribution to use. Defaults to ``parametric``. To choose from:
 
@@ -406,17 +406,16 @@ class BayesGMMTransformer(NumericalTransformer):
             Data type of the data to transform. It will be used when reversing the
             transformation. If not provided, the dtype of the fit data will be used.
             Defaults to ``None``.
-        missing_value_replacement (int, str or None):
-            Indicate what to do with the null values. If an integer is given, replace them
-            with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
-            them with the corresponding aggregation. If ``None`` is given, do not replace them.
-            Defaults to ``'mean'``.
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an integer or float is given,
+            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are
+            given, replace them with the corresponding aggregation. If ``None`` is given,
+            do not replace them. Defaults to ``None``.
         model_missing_values (bool):
-            Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            Whether to create a new column to indicate which values were null or not. The column
+            will be created only if there are null values. If ``True``, create the new column if
+            there are null values. If ``False``, do not create the new column even if there
+            are null values. Defaults to ``False``.
         rounding (int, str or None):
             Define rounding scheme for data. If set to an int, values will be rounded
             to that number of decimal places. If ``None``, values will not be rounded.

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -67,7 +67,7 @@ class NumericalTransformer(BaseTransformer):
     _min_value = None
     _max_value = None
 
-    def __init__(self, dtype=None, missing_value_replacement='mean', model_missing_values=True,
+    def __init__(self, dtype=None, missing_value_replacement=None, model_missing_values=False,
                  rounding=None, min_value=None, max_value=None):
         self.missing_value_replacement = missing_value_replacement
         self.model_missing_values = model_missing_values
@@ -258,8 +258,8 @@ class GaussianCopulaTransformer(NumericalTransformer):
     _univariate = None
     COMPOSITION_IS_IDENTITY = False
 
-    def __init__(self, dtype=None, missing_value_replacement='mean',
-                 model_missing_values=True, distribution='parametric'):
+    def __init__(self, dtype=None, missing_value_replacement=None,
+                 model_missing_values=False, distribution='parametric'):
         super().__init__(
             dtype=dtype,
             missing_value_replacement=missing_value_replacement,
@@ -459,7 +459,7 @@ class BayesGMMTransformer(NumericalTransformer):
     _bgm_transformer = None
     valid_component_indicator = None
 
-    def __init__(self, dtype=None, missing_value_replacement='mean', model_missing_values=True,
+    def __init__(self, dtype=None, missing_value_replacement=None, model_missing_values=False,
                  rounding=None, min_value=None, max_value=None, max_clusters=10,
                  weight_threshold=0.005):
         super().__init__(

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -27,17 +27,15 @@ class NumericalTransformer(BaseTransformer):
             Data type of the data to transform. It will be used when reversing the
             transformation. If not provided, the dtype of the fit data will be used.
             Defaults to ``None``.
-        missing_value_replacement (int, str or None):
-            Indicate what to do with the null values. If an integer is given, replace them
-            with the given value. If the strings ``'mean'`` or ``'mode'`` are given, replace
-            them with the corresponding aggregation. If ``None`` is given, do not replace them.
-            Defaults to ``'mean'``.
+        missing_value_replacement (object or None):
+            Indicate what to do with the null values. If an integer or float is given,
+            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are
+            given, replace them with the corresponding aggregation. If ``None`` is given,
+            do not replace them. Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not.
-            If ``None``, only create a new column when the data contains null values.
-            If ``True``, always create the new column whether there are null values or not.
-            If ``False``, do not create the new column.
-            Defaults to ``None``.
+            If ``True``, create the new column if there are null values.
+            If ``False``, do not create the new column. Defaults to ``False``.
         rounding (int, str or None):
             Define rounding scheme for data. If set to an int, values will be rounded
             to that number of decimal places. If ``None``, values will not be rounded.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "numpy>=1.18.0,<1.20.0;python_version<'3.7'",
     "numpy>=1.20.0,<2;python_version>='3.7'",
     'pandas>=1.1.3,<2',
-    'scipy>=1.5.4,<2',
+    'scipy>=1.5.4,<1.8',
     'psutil>=5.7,<6',
     'scikit-learn>=0.24,<2',
     'pyyaml>=5.4.1,<6'

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -113,7 +113,7 @@ def get_input_data():
 
 def get_transformed_data():
     datetimes = [
-        1.263069e+18,
+        np.nan,
         1.264982e+18,
         1.262304e+18,
         1.262304e+18,
@@ -124,13 +124,10 @@ def get_transformed_data():
     ]
     return pd.DataFrame({
         'integer.value': [1, 2, 1, 3, 1, 4, 2, 3],
-        'float.value': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
-        'float.is_null': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+        'float.value': [0.1, 0.2, 0.1, np.nan, 0.1, 0.4, np.nan, 0.3],
         'categorical.value': [0.3125, 0.3125, 0.9375, 0.75, 0.3125, 0.75, 0.3125, 0.3125],
-        'bool.value': [0.0, -1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0],
-        'bool.is_null': [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        'bool.value': [0.0, np.nan, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0],
         'datetime.value': datetimes,
-        'datetime.is_null': [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         'names.value': [0.3125, 0.75, 0.75, 0.3125, 0.3125, 0.9375, 0.3125, 0.3125]
     }, index=TEST_DATA_INDEX)
 
@@ -177,13 +174,13 @@ def test_hypertransformer_default_inputs():
     assert isinstance(ht._transformers_tree['integer']['transformer'], NumericalTransformer)
     assert ht._transformers_tree['integer']['outputs'] == ['integer.value']
     assert isinstance(ht._transformers_tree['float']['transformer'], NumericalTransformer)
-    assert ht._transformers_tree['float']['outputs'] == ['float.value', 'float.is_null']
+    assert ht._transformers_tree['float']['outputs'] == ['float.value']
     assert isinstance(ht._transformers_tree['categorical']['transformer'], CategoricalTransformer)
     assert ht._transformers_tree['categorical']['outputs'] == ['categorical.value']
     assert isinstance(ht._transformers_tree['bool']['transformer'], BooleanTransformer)
-    assert ht._transformers_tree['bool']['outputs'] == ['bool.value', 'bool.is_null']
+    assert ht._transformers_tree['bool']['outputs'] == ['bool.value']
     assert isinstance(ht._transformers_tree['datetime']['transformer'], DatetimeTransformer)
-    assert ht._transformers_tree['datetime']['outputs'] == ['datetime.value', 'datetime.is_null']
+    assert ht._transformers_tree['datetime']['outputs'] == ['datetime.value']
     assert isinstance(ht._transformers_tree['names']['transformer'], CategoricalTransformer)
     assert ht._transformers_tree['names']['outputs'] == ['names.value']
 
@@ -228,7 +225,6 @@ def test_hypertransformer_field_transformers():
 
     # Assert
     expected_transformed = get_transformed_data()
-    del expected_transformed['datetime.is_null']
     rename = {'datetime.value': 'datetime.value.value'}
     expected_transformed = expected_transformed.rename(columns=rename)
     transformed_datetimes = [0.9375, 0.75, 0.3125, 0.3125, 0.3125, 0.75, 0.3125, 0.3125]

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -13,6 +13,41 @@ TEST_COL = 'test_col'
 
 PRIMARY_DATA_TYPES = ['boolean', 'categorical', 'datetime', 'numerical']
 
+# Additional arguments for transformers
+TRANSFORMER_ARGS = {
+    'BooleanTransformer': {
+        'missing_value_replacement': -1,
+        'model_missing_values': True
+    },
+    'DatetimeTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'DatetimeRoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalRoundedBoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'NumericalBoundedTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'GaussianCopulaTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+    'BayesGMMTransformer': {
+        'missing_value_replacement': 'mean',
+        'model_missing_values': True
+    },
+}
 
 # Mapping of rdt data type to dtype
 DATA_TYPE_TO_DTYPES = {
@@ -146,7 +181,9 @@ def _test_transformer_with_dataset(transformer_class, input_data, steps):
         steps (list):
             List of steps that the validation has completed.
     """
-    transformer = transformer_class()
+
+    transformer_args = TRANSFORMER_ARGS.get(transformer_class.__name__, {})
+    transformer = transformer_class(**transformer_args)
     # Fit
     transformer.fit(input_data, [TEST_COL])
 
@@ -204,9 +241,16 @@ def _test_transformer_with_hypertransformer(transformer_class, input_data, steps
         steps (list):
             List of steps that the validation has completed.
     """
-    hypertransformer = HyperTransformer(field_transformers={
-        TEST_COL: transformer_class.__name__,
-    })
+    transformer_args = TRANSFORMER_ARGS.get(transformer_class.__name__, {})
+    if transformer_args:
+        hypertransformer = HyperTransformer(field_transformers={
+            TEST_COL: transformer_class(**transformer_args),
+        })
+    else:
+        hypertransformer = HyperTransformer(field_transformers={
+            TEST_COL: transformer_class.__name__,
+        })
+
     hypertransformer.fit(input_data)
 
     transformed = hypertransformer.transform(input_data)

--- a/tests/integration/transformers/test_datetime.py
+++ b/tests/integration/transformers/test_datetime.py
@@ -5,7 +5,7 @@ from rdt.transformers.datetime import DatetimeTransformer
 
 
 def test_no_strip():
-    dtt = DatetimeTransformer(strip_constant=False)
+    dtt = DatetimeTransformer(missing_value_replacement='mean', strip_constant=False)
     data = pd.to_datetime(pd.Series([None, '1996-10-17', '1965-05-23']))
     dtt.columns = 'column'
 
@@ -25,7 +25,7 @@ def test_no_strip():
 
 
 def test_strip():
-    dtt = DatetimeTransformer(strip_constant=True)
+    dtt = DatetimeTransformer(missing_value_replacement='mean', strip_constant=True)
     data = pd.to_datetime(pd.Series([None, '1996-10-17', '1965-05-23']))
     dtt.columns = 'column'
 

--- a/tests/integration/transformers/test_datetime.py
+++ b/tests/integration/transformers/test_datetime.py
@@ -16,9 +16,9 @@ def test_no_strip():
 
     # Asserts
     expect_trans = np.array([
-        [350006400000000000, 1.0],
-        [845510400000000000, 0.0],
-        [-145497600000000000, 0.0]
+        np.nan,
+        845510400000000000,
+        -145497600000000000
     ])
     np.testing.assert_almost_equal(expect_trans, transformed)
     pd.testing.assert_series_equal(reverted, data)
@@ -36,9 +36,9 @@ def test_strip():
 
     # Asserts
     expect_trans = np.array([
-        [4051.0, 1.0],
-        [9786.0, 0.0],
-        [-1684.0, 0.0]
+        np.nan,
+        9786.0,
+        -1684.0
     ])
     np.testing.assert_almost_equal(expect_trans, transformed)
     pd.testing.assert_series_equal(reverted, data)

--- a/tests/integration/transformers/test_datetime.py
+++ b/tests/integration/transformers/test_datetime.py
@@ -7,6 +7,7 @@ from rdt.transformers.datetime import DatetimeTransformer
 def test_no_strip():
     dtt = DatetimeTransformer(strip_constant=False)
     data = pd.to_datetime(pd.Series([None, '1996-10-17', '1965-05-23']))
+    dtt.columns = 'column'
 
     # Run
     dtt._fit(data.copy())
@@ -26,6 +27,7 @@ def test_no_strip():
 def test_strip():
     dtt = DatetimeTransformer(strip_constant=True)
     data = pd.to_datetime(pd.Series([None, '1996-10-17', '1965-05-23']))
+    dtt.columns = 'column'
 
     # Run
     dtt._fit(data.copy())

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -59,24 +59,6 @@ class TestNumericalTransformer:
         data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
         column = 'a'
 
-        nt = NumericalTransformer(
-            missing_value_replacement='mean',
-            model_missing_values=True,
-            dtype=int,
-        )
-        nt.fit(data, column)
-        transformed = nt.transform(data)
-
-        assert isinstance(transformed, pd.DataFrame)
-        assert transformed.shape == (6, 2)
-
-        reverse = nt.reverse_transform(transformed)
-        np.testing.assert_array_almost_equal(reverse, data, decimal=2)
-
-    def test_int_nan_not_model_missing_values(self):
-        data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
-        column = 'a'
-
         nt = NumericalTransformer(dtype=int)
         nt.fit(data, column)
         transformed = nt.transform(data)

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -11,7 +11,10 @@ class TestNumericalTransformer:
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        nt = NumericalTransformer()
+        nt = NumericalTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True,
+        )
         nt.fit(data, column)
         transformed = nt.transform(data)
 
@@ -52,7 +55,25 @@ class TestNumericalTransformer:
         reverse = nt.reverse_transform(transformed)
         assert list(reverse['a']) == [1, 2, 1, 2, 1]
 
-    def test_int_nan(self):
+    def test_int_nan_not_model_missing_values(self):
+        data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
+        column = 'a'
+
+        nt = NumericalTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True,
+            dtype=int,
+        )
+        nt.fit(data, column)
+        transformed = nt.transform(data)
+
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.shape == (6, 2)
+
+        reverse = nt.reverse_transform(transformed)
+        np.testing.assert_array_almost_equal(reverse, data, decimal=2)
+
+    def test_int_nan_not_model_missing_values(self):
         data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
         column = 'a'
 
@@ -61,7 +82,7 @@ class TestNumericalTransformer:
         transformed = nt.transform(data)
 
         assert isinstance(transformed, pd.DataFrame)
-        assert transformed.shape == (6, 2)
+        assert transformed.shape == (6, 1)
 
         reverse = nt.reverse_transform(transformed)
         np.testing.assert_array_almost_equal(reverse, data, decimal=2)
@@ -91,7 +112,10 @@ class TestGaussianCopulaTransformer:
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        ct = GaussianCopulaTransformer()
+        ct = GaussianCopulaTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -107,7 +131,10 @@ class TestGaussianCopulaTransformer:
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        ct = GaussianCopulaTransformer(model_missing_values=False)
+        ct = GaussianCopulaTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=False
+        )
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -136,7 +163,10 @@ class TestGaussianCopulaTransformer:
         data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
         column = 'a'
 
-        ct = GaussianCopulaTransformer(dtype=int)
+        ct = GaussianCopulaTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -179,7 +209,10 @@ class TestBayesGMMTransformer:
         data[mask] = np.nan
         column = 'col'
 
-        bgmm_transformer = BayesGMMTransformer()
+        bgmm_transformer = BayesGMMTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
         bgmm_transformer.fit(data, column)
         transformed = bgmm_transformer.transform(data)
 
@@ -197,7 +230,10 @@ class TestBayesGMMTransformer:
         data = pd.DataFrame([np.nan, None] * 50, columns=['col'])
         column = 'col'
 
-        bgmm_transformer = BayesGMMTransformer(missing_value_replacement=0)
+        bgmm_transformer = BayesGMMTransformer(
+            missing_value_replacement=0,
+            model_missing_values=True
+        )
         bgmm_transformer.fit(data, column)
         transformed = bgmm_transformer.transform(data)
 

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -7,7 +7,7 @@ from rdt.transformers.numerical import (
 
 class TestNumericalTransformer:
 
-    def test_null_column(self):
+    def test_model_missing_values(self):
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
@@ -23,11 +23,11 @@ class TestNumericalTransformer:
 
         np.testing.assert_array_almost_equal(reverse, data, decimal=2)
 
-    def test_not_null_column(self):
+    def test_not_model_missing_values(self):
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        nt = NumericalTransformer(null_column=False)
+        nt = NumericalTransformer(model_missing_values=False)
         nt.fit(data, column)
         transformed = nt.transform(data)
 
@@ -87,7 +87,7 @@ class TestGaussianCopulaTransformer:
 
         np.testing.assert_array_almost_equal(reverse, data, decimal=1)
 
-    def test_null_column(self):
+    def test_model_missing_values(self):
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
@@ -103,11 +103,11 @@ class TestGaussianCopulaTransformer:
 
         np.testing.assert_array_almost_equal(reverse, data, decimal=2)
 
-    def test_not_null_column(self):
+    def test_not_model_missing_values(self):
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        ct = GaussianCopulaTransformer(null_column=False)
+        ct = GaussianCopulaTransformer(model_missing_values=False)
         ct.fit(data, column)
         transformed = ct.transform(data)
 

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -197,7 +197,7 @@ class TestBayesGMMTransformer:
         data = pd.DataFrame([np.nan, None] * 50, columns=['col'])
         column = 'col'
 
-        bgmm_transformer = BayesGMMTransformer()
+        bgmm_transformer = BayesGMMTransformer(missing_value_replacement=0)
         bgmm_transformer.fit(data, column)
         transformed = bgmm_transformer.transform(data)
 

--- a/tests/quality/test_quality.py
+++ b/tests/quality/test_quality.py
@@ -86,7 +86,7 @@ def get_transformer_regression_scores(data, data_type, dataset_name, transformer
 
     for column in columns_to_predict:
         target = data[column].to_frame()
-        numerical_transformer = NumericalTransformer(null_column=False)
+        numerical_transformer = NumericalTransformer(model_missing_values=False)
         target = numerical_transformer.fit_transform(target, column)
         target = format_array(target)
         for transformer in transformers:

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -44,12 +44,12 @@ def test_get_transformer_class_transformer_path():
 
 
 def test_get_transformer_instance_instance():
-    transformer = BooleanTransformer(nan=None)
+    transformer = BooleanTransformer(missing_value_replacement=None)
 
     returned = get_transformer_instance(transformer)
 
     assert isinstance(returned, BooleanTransformer)
-    assert returned.nan is None
+    assert returned.missing_value_replacement is None
 
 
 def test_get_transformer_instance_str():

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -162,15 +162,15 @@ class TestBaseTransformer:
         """
         # Setup
         class Dummy(BaseTransformer):
-            columns = ['col1, col2, col3']
+            columns = ['col1', 'col2', 'col3']
 
         dummy_transformer = Dummy()
 
         # Run
-        output = dummy_transformer.get_input_columns()
+        output = dummy_transformer.get_input_column()
 
         # Assert
-        expected = ['col1, col2, col3']
+        expected = 'col1'
         assert output == expected
 
     def test_get_output_columns(self):

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -20,7 +20,7 @@ class TestBooleanTransformer(TestCase):
         assert transformer.missing_value_replacement is None, error_message
         assert not transformer.model_missing_values, 'model_missing_values is False by default'
 
-    def test_get_output_types_model_missing_values_created(self):
+    def test_get_output_types_model_missing_values_column_created(self):
         """Test the ``get_output_types`` method when a null column is created.
 
         When a null column is created, this method should apply the ``_add_prefix``
@@ -68,7 +68,7 @@ class TestBooleanTransformer(TestCase):
 
         # Asserts
         error_msg = 'Unexpected fill value'
-        assert transformer.null_transformer.missing_value_replacement is None, error_msg
+        assert transformer.null_transformer._missing_value_replacement is None, error_msg
 
     def test__fit_missing_value_replacement_not_ignore(self):
         """Test _fit missing_value_replacement not equal to ignore"""
@@ -80,7 +80,7 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.missing_value_replacement == 0, 'Unexpected fill value'
+        assert transformer.null_transformer._missing_value_replacement == 0, 'Unexpected fill value'
 
     def test__fit_array(self):
         """Test _fit with numpy.array"""
@@ -92,7 +92,7 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.missing_value_replacement == 0, 'Unexpected fill value'
+        assert transformer.null_transformer._missing_value_replacement == 0, 'Unexpected fill value'
 
     def test__transform_series(self):
         """Test transform pandas.Series"""

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -17,7 +17,7 @@ class TestBooleanTransformer(TestCase):
 
         # Asserts
         error_message = 'Unexpected missing_value_replacement'
-        assert transformer.missing_value_replacement == None, error_message
+        assert transformer.missing_value_replacement is None, error_message
         assert not transformer.model_missing_values, 'model_missing_values is False by default'
 
     def test_get_output_types_model_missing_values_created(self):
@@ -68,7 +68,8 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.missing_value_replacement is None, 'Unexpected fill value'
+        error_msg = 'Unexpected fill value'
+        assert transformer.null_transformer.missing_value_replacement is None, error_msg
 
     def test__fit_missing_value_replacement_not_ignore(self):
         """Test _fit missing_value_replacement not equal to ignore"""
@@ -181,7 +182,10 @@ class TestBooleanTransformer(TestCase):
 
         np.testing.assert_equal(result, expect)
 
-        error_msg = 'NullTransformer.reverse_transform should not be called when missing_value_replacement is ignore'
+        error_msg = (
+            'NullTransformer.reverse_transform should not be called when '
+            'missing_value_replacement is ignore'
+        )
         reverse_transform_call_count = transformer.null_transformer.reverse_transform.call_count
         assert reverse_transform_call_count == expect_call_count, error_msg
 

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -16,10 +16,11 @@ class TestBooleanTransformer(TestCase):
         transformer = BooleanTransformer()
 
         # Asserts
-        assert transformer.nan == -1, 'Unexpected nan'
-        assert transformer.null_column is None, 'null_column is None by default'
+        error_message = 'Unexpected missing_value_replacement'
+        assert transformer.missing_value_replacement == None, error_message
+        assert not transformer.model_missing_values, 'model_missing_values is False by default'
 
-    def test_get_output_types_null_column_created(self):
+    def test_get_output_types_model_missing_values_created(self):
         """Test the ``get_output_types`` method when a null column is created.
 
         When a null column is created, this method should apply the ``_add_prefix``
@@ -33,7 +34,7 @@ class TestBooleanTransformer(TestCase):
         Setup:
             - initialize a ``BooleanTransformer`` transformer which:
                 - sets ``self.null_transformer`` to a ``NullTransformer`` where
-                ``self._null_column`` is True.
+                ``self._model_missing_values`` is True.
                 - sets ``self.column_prefix`` to a string.
 
         Output:
@@ -42,8 +43,8 @@ class TestBooleanTransformer(TestCase):
         """
         # Setup
         transformer = BooleanTransformer()
-        transformer.null_transformer = NullTransformer(fill_value='fill')
-        transformer.null_transformer._null_column = True
+        transformer.null_transformer = NullTransformer(missing_value_replacement='fill')
+        transformer.null_transformer._model_missing_values = True
         transformer.column_prefix = 'abc'
 
         # Run
@@ -56,29 +57,31 @@ class TestBooleanTransformer(TestCase):
         }
         assert output == expected
 
-    def test__fit_nan_ignore(self):
-        """Test _fit nan equal to ignore"""
+    def test__fit_missing_value_replacement_ignore(self):
+        """Test _fit missing_value_replacement equal to ignore"""
         # Setup
         data = pd.Series([False, True, True, False, True])
 
         # Run
-        transformer = BooleanTransformer(nan=None)
+        transformer = BooleanTransformer(missing_value_replacement=None)
+        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.fill_value is None, 'Unexpected fill value'
+        assert transformer.null_transformer.missing_value_replacement is None, 'Unexpected fill value'
 
-    def test__fit_nan_not_ignore(self):
-        """Test _fit nan not equal to ignore"""
+    def test__fit_missing_value_replacement_not_ignore(self):
+        """Test _fit missing_value_replacement not equal to ignore"""
         # Setup
         data = pd.Series([False, True, True, False, True])
 
         # Run
-        transformer = BooleanTransformer(nan=0)
+        transformer = BooleanTransformer(missing_value_replacement=0)
+        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.fill_value == 0, 'Unexpected fill value'
+        assert transformer.null_transformer.missing_value_replacement == 0, 'Unexpected fill value'
 
     def test__fit_array(self):
         """Test _fit with numpy.array"""
@@ -86,11 +89,12 @@ class TestBooleanTransformer(TestCase):
         data = pd.Series([False, True, True, False, True])
 
         # Run
-        transformer = BooleanTransformer(nan=0)
+        transformer = BooleanTransformer(missing_value_replacement=0)
+        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer.fill_value == 0, 'Unexpected fill value'
+        assert transformer.null_transformer.missing_value_replacement == 0, 'Unexpected fill value'
 
     def test__transform_series(self):
         """Test transform pandas.Series"""
@@ -134,14 +138,15 @@ class TestBooleanTransformer(TestCase):
             expect_call_args
         )
 
-    def test__reverse_transform_nan_ignore(self):
-        """Test _reverse_transform with nan equal to ignore"""
+    def test__reverse_transform_missing_value_replacement_ignore(self):
+        """Test _reverse_transform with missing_value_replacement equal to ignore"""
         # Setup
         data = pd.Series([0.0, 1.0, 0.0, 1.0, 0.0])
 
         # Run
         transformer = Mock()
-        transformer.nan = None
+        transformer.columns = ['column']
+        transformer.missing_value_replacement = None
 
         result = BooleanTransformer._reverse_transform(transformer, data)
 
@@ -150,19 +155,22 @@ class TestBooleanTransformer(TestCase):
         expect_call_count = 0
 
         np.testing.assert_equal(result, expect)
-        error_msg = 'NullTransformer.reverse_transform should not be called when nan is ignore'
+        error_msg = (
+            'NullTransformer.reverse_transform should not be called when'
+            'missing_value_replacement is ignore'
+        )
         transformer_call_count = transformer.null_transformer.reverse_transform.call_count
         assert transformer_call_count == expect_call_count, error_msg
 
-    def test__reverse_transform_nan_not_ignore(self):
-        """Test _reverse_transform with nan not equal to ignore"""
+    def test__reverse_transform_missing_value_replacement_not_ignore(self):
+        """Test _reverse_transform with missing_value_replacement not equal to ignore"""
         # Setup
         data = np.array([0.0, 1.0, 0.0, 1.0, 0.0])
         transformed_data = np.array([0.0, 1.0, 0.0, 1.0, 0.0])
 
         # Run
         transformer = Mock()
-        transformer.nan = 0
+        transformer.missing_value_replacement = 0
         transformer.null_transformer.reverse_transform.return_value = transformed_data
 
         result = BooleanTransformer._reverse_transform(transformer, data)
@@ -173,7 +181,7 @@ class TestBooleanTransformer(TestCase):
 
         np.testing.assert_equal(result, expect)
 
-        error_msg = 'NullTransformer.reverse_transform should not be called when nan is ignore'
+        error_msg = 'NullTransformer.reverse_transform should not be called when missing_value_replacement is ignore'
         reverse_transform_call_count = transformer.null_transformer.reverse_transform.call_count
         assert reverse_transform_call_count == expect_call_count, error_msg
 
@@ -184,7 +192,7 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = Mock()
-        transformer.nan = None
+        transformer.missing_value_replacement = None
 
         result = BooleanTransformer._reverse_transform(transformer, data)
 
@@ -201,7 +209,7 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = Mock()
-        transformer.nan = None
+        transformer.missing_value_replacement = None
 
         result = BooleanTransformer._reverse_transform(transformer, data)
 
@@ -225,7 +233,7 @@ class TestBooleanTransformer(TestCase):
         # Setup
         data = np.array([1.2, 0.32, 1.01])
         transformer = Mock()
-        transformer.nan = None
+        transformer.missing_value_replacement = None
 
         # Run
         result = BooleanTransformer._reverse_transform(transformer, data)
@@ -251,7 +259,7 @@ class TestBooleanTransformer(TestCase):
         # Setup
         data = np.array([1.9, -0.7, 1.01])
         transformer = Mock()
-        transformer.nan = None
+        transformer.missing_value_replacement = None
 
         # Run
         result = BooleanTransformer._reverse_transform(transformer, data)

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -64,7 +64,6 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = BooleanTransformer(missing_value_replacement=None)
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -78,7 +77,6 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = BooleanTransformer(missing_value_replacement=0)
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -91,7 +89,6 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = BooleanTransformer(missing_value_replacement=0)
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -146,7 +143,6 @@ class TestBooleanTransformer(TestCase):
 
         # Run
         transformer = Mock()
-        transformer.columns = ['column']
         transformer.missing_value_replacement = None
 
         result = BooleanTransformer._reverse_transform(transformer, data)

--- a/tests/unit/transformers/test_boolean.py
+++ b/tests/unit/transformers/test_boolean.py
@@ -80,7 +80,8 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer._missing_value_replacement == 0, 'Unexpected fill value'
+        error_msg = 'Unexpected fill value'
+        assert transformer.null_transformer._missing_value_replacement == 0, error_msg
 
     def test__fit_array(self):
         """Test _fit with numpy.array"""
@@ -92,7 +93,8 @@ class TestBooleanTransformer(TestCase):
         transformer._fit(data)
 
         # Asserts
-        assert transformer.null_transformer._missing_value_replacement == 0, 'Unexpected fill value'
+        error_msg = 'Unexpected fill value'
+        assert transformer.null_transformer._missing_value_replacement == 0, error_msg
 
     def test__transform_series(self):
         """Test transform pandas.Series"""

--- a/tests/unit/transformers/test_datetime.py
+++ b/tests/unit/transformers/test_datetime.py
@@ -329,7 +329,6 @@ class TestDatetimeTransformer:
         # Setup
         data = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
         transformer = DatetimeTransformer()
-        transformer.columns = ['column']
 
         # Run
         transformer._fit(data)
@@ -378,7 +377,6 @@ class TestDatetimeTransformer:
     def test__reverse_transform_all_none(self):
         dt = pd.to_datetime(['2020-01-01'])
         dtt = DatetimeTransformer(missing_value_replacement='mean', strip_constant=True)
-        dtt.columns = ['column']
         dtt._fit(dt)
 
         output = dtt._reverse_transform(pd.Series([None]))
@@ -400,7 +398,6 @@ class TestDatetimeTransformer:
         # Setup
         dt = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
         dtt = DatetimeTransformer(missing_value_replacement=None, strip_constant=True)
-        dtt.columns = ['column']
         dtt._fit(dt)
         transformed = np.array([[18262.], [18293.], [18322.]])
 

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -19,8 +19,8 @@ class TestNullTransformer:
             - nothing
 
         Expected Side Effects:
-            - The `missing_value_replacement` attribute should be `None`.
-            - The `_model_missing_values` attribute should be `None`.
+            - The `_missing_value_replacement` attribute should be `None`.
+            - The `_model_missing_values` attribute should be `False`.
         """
         # Run
         transformer = NullTransformer()
@@ -265,9 +265,9 @@ class TestNullTransformer:
     def test_fit_model_missing_values_none_and_no_nulls(self):
         """Test fit when null column is none and there are NO nulls.
 
-        If there are no nulls in the data and model_missing_values was given as None,
-        then the _model_missing_values attribute should be set to False.
-        Also validate that the null attribute and the _missing_value_replacement attributes
+        If there are no nulls in the data and model_missing_values was given as ``False``,
+        then the _model_missing_values attribute should be set to ``False``.
+        Also validate that the null attribute and the ``_missing_value_replacement`` attributes
         are set accordingly.
 
         Setup:

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -20,14 +20,14 @@ class TestNullTransformer:
 
         Expected Side Effects:
             - The `missing_value_replacement` attribute should be `None`.
-            - The `model_missing_values` attribute should be `None`.
+            - The `_model_missing_values` attribute should be `None`.
         """
         # Run
         transformer = NullTransformer()
 
         # Assert
         assert transformer.missing_value_replacement is None
-        assert not transformer.model_missing_values
+        assert not transformer._model_missing_values
 
     def test___init__not_default(self):
         """Test the initialization passing values different than defaults.
@@ -46,7 +46,7 @@ class TestNullTransformer:
 
         # Assert
         assert transformer.missing_value_replacement == 'a_missing_value_replacement'
-        assert not transformer.model_missing_values
+        assert not transformer._model_missing_values
 
     def test_models_missing_values(self):
         """Test the models_missing_values method.

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -19,17 +19,15 @@ class TestNullTransformer:
             - nothing
 
         Expected Side Effects:
-            - The `fill_value` attribute should be `None`.
-            - The `null_column` attribute should be `None`.
-            - The `copy` attribute should be `False`.
+            - The `missing_value_replacement` attribute should be `None`.
+            - The `model_missing_values` attribute should be `None`.
         """
         # Run
         transformer = NullTransformer()
 
         # Assert
-        assert transformer.fill_value is None
-        assert transformer.null_column is None
-        assert not transformer.copy
+        assert transformer.missing_value_replacement is None
+        assert not transformer.model_missing_values
 
     def test___init__not_default(self):
         """Test the initialization passing values different than defaults.
@@ -44,43 +42,42 @@ class TestNullTransformer:
             - The attributes should be populated with the given values.
         """
         # Run
-        transformer = NullTransformer('a_fill_value', False, True)
+        transformer = NullTransformer('a_missing_value_replacement', False)
 
         # Assert
-        assert transformer.fill_value == 'a_fill_value'
-        assert not transformer.null_column
-        assert transformer.copy
+        assert transformer.missing_value_replacement == 'a_missing_value_replacement'
+        assert not transformer.model_missing_values
 
-    def test_creates_null_column(self):
-        """Test the creates_null_column method.
+    def test_creates_model_missing_values(self):
+        """Test the creates_model_missing_values method.
 
-        If the `null_column` attributes evalutes to True, the `create_null_column`
-        method should return the same value.
+        If the `model_missing_values` attributes evalutes to True, the
+        `create_model_missing_values` method should return the same value.
 
         Setup:
-            - Create an instance and set _null_column to True
+            - Create an instance and set _model_missing_values to True
 
         Expected Output:
             - True
         """
         # Setup
-        transformer = NullTransformer('something', null_column=True)
-        transformer._null_column = True
+        transformer = NullTransformer('something', model_missing_values=True)
+        transformer._model_missing_values = True
 
         # Run
-        creates_null_column = transformer.creates_null_column()
+        creates_model_missing_values = transformer.creates_model_missing_values()
 
         # Assert
-        assert creates_null_column
+        assert creates_model_missing_values
 
-    def test__get_fill_value_scalar(self):
-        """Test _get_fill_value when a scalar value is passed.
+    def test__get_missing_value_replacement_scalar(self):
+        """Test _get_missing_value_replacement when a scalar value is passed.
 
-        If a fill_value different from None, 'mean' or 'mode' is
+        If a missing_value_replacement different from None, 'mean' or 'mode' is
         passed to __init__, that value is returned.
 
         Setup:
-            - NullTransformer passing a specific fill_value
+            - NullTransformer passing a specific missing_value_replacement
               that is not None, mean or mode.
 
         Input:
@@ -91,24 +88,23 @@ class TestNullTransformer:
             - The value passed to __init__
         """
         # Setup
-        transformer = NullTransformer('a_fill_value')
+        transformer = NullTransformer('a_missing_value_replacement')
 
         # Run
         data = pd.Series([1, np.nan, 3], name='abc')
-        null_values = np.array([False, True, False])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 'a_fill_value'
+        assert missing_value_replacement == 'a_missing_value_replacement'
 
-    def test__get_fill_value_all_nulls(self):
-        """Test _get_fill_value when all the values are null.
+    def test__get_missing_value_replacement_all_nulls(self):
+        """Test _get_missing_value_replacement when all the values are null.
 
-        If the fill_value is not a scalar value and all the data
-        values are null, the output should be 0.
+        If the missing_value_replacement is not a scalar value and all the data
+        values are null, the output be the mean, which is `np.nan`.
 
         Setup:
-            - NullTransformer passing 'mean' as the fill_value.
+            - NullTransformer passing 'mean' as the missing_value_replacement.
 
         Input:
             - A Series filled with nan values.
@@ -122,16 +118,15 @@ class TestNullTransformer:
 
         # Run
         data = pd.Series([np.nan, np.nan, np.nan], name='abc')
-        null_values = np.array([True, True, True])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 0
+        assert missing_value_replacement is np.nan
 
-    def test__get_fill_value_none_numerical(self):
-        """Test _get_fill_value when fill_value is None and data is numerical.
+    def test__get_missing_value_replacement_none_numerical(self):
+        """Test _get_missing_value_replacement when missing_value_replacement is None.
 
-        If the fill_value is None and the data is numerical,
+        If the missing_value_replacement is None and the data is numerical,
         the output fill value should be the mean of the input data.
 
         Setup:
@@ -146,20 +141,19 @@ class TestNullTransformer:
             - The mean of the inputted Series.
         """
         # Setup
-        transformer = NullTransformer()
+        transformer = NullTransformer('mean')
 
         # Run
         data = pd.Series([1, 2, np.nan], name='abc')
-        null_values = np.array([False, False, True])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 1.5
+        assert missing_value_replacement == 1.5
 
-    def test__get_fill_value_none_not_numerical(self):
-        """Test _get_fill_value when fill_value is None and data is not numerical.
+    def test__get_missing_value_replacement_none_not_numerical(self):
+        """Test _get_missing_value_replacement when missing_value_replacement is None.
 
-        If the fill_value is None and the data is not numerical,
+        If the missing_value_replacement is None and the data is not numerical,
         the output fill value should be the mode of the input data.
 
         Setup:
@@ -174,24 +168,23 @@ class TestNullTransformer:
             - The most frequent value in the input series.
         """
         # Setup
-        transformer = NullTransformer()
+        transformer = NullTransformer('mode')
 
         # Run
         data = pd.Series(['a', 'b', 'b', np.nan], name='abc')
-        null_values = np.array([False, False, False, True])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 'b'
+        assert missing_value_replacement == 'b'
 
-    def test__get_fill_value_mean(self):
-        """Test _get_fill_value when fill_value is mean.
+    def test__get_missing_value_replacement_mean(self):
+        """Test _get_missing_value_replacement when missing_value_replacement is mean.
 
-        If the fill_value is mean the output fill value should be the
+        If the missing_value_replacement is mean the output fill value should be the
         mean of the input data.
 
         Setup:
-            - NullTransformer passing 'mean' as the fill_value.
+            - NullTransformer passing 'mean' as the missing_value_replacement.
 
         Input:
             - A Series filled with integer values such that the mean
@@ -206,20 +199,19 @@ class TestNullTransformer:
 
         # Run
         data = pd.Series([1, 2, np.nan], name='abc')
-        null_values = np.array([False, False, True])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 1.5
+        assert missing_value_replacement == 1.5
 
-    def test__get_fill_value_mode(self):
-        """Test _get_fill_value when fill_value is 'mode'.
+    def test__get_missing_value_replacement_mode(self):
+        """Test _get_missing_value_replacement when missing_value_replacement is 'mode'.
 
-        If the fill_value is 'mode' the output fill value should be the
+        If the missing_value_replacement is 'mode' the output fill value should be the
         mode of the input data.
 
         Setup:
-            - NullTransformer passing 'mode' as the fill_value.
+            - NullTransformer passing 'mode' as the missing_value_replacement.
 
         Input:
             - A Series filled with integer values such that the mean
@@ -234,18 +226,17 @@ class TestNullTransformer:
 
         # Run
         data = pd.Series([1, 2, 2, np.nan], name='abc')
-        null_values = np.array([False, False, False, True])
-        fill_value = transformer._get_fill_value(data, null_values)
+        missing_value_replacement = transformer._get_missing_value_replacement(data)
 
         # Assert
-        assert fill_value == 2
+        assert missing_value_replacement == 2
 
-    def test_fit_null_column_none_and_nulls(self):
+    def test_fit_model_missing_values_none_and_nulls(self):
         """Test fit when null column is none and there are nulls.
 
-        If there are nulls in the data and null_column was given as None,
-        then the _null_column attribute should be set to True.
-        Also validate that the null attribute and the _fill_value attributes
+        If there are nulls in the data and model_missing_values was given as None,
+        then the _model_missing_values attribute should be set to True.
+        Also validate that the null attribute and the _missing_value_replacement attributes
         are set accordingly.
 
         Setup:
@@ -255,28 +246,28 @@ class TestNullTransformer:
             - pd.Series of integers that contains nulls.
 
         Expected Side Effects:
-            - the null_column attribute should be set to True.
+            - the model_missing_values attribute should be set to True.
             - the nulls attribute should be set to True.
-            - the fill_value should be set to the mean of the given integers.
+            - the missing_value_replacement should be set to the mean of the given integers.
         """
         # Setup
-        transformer = NullTransformer()
+        transformer = NullTransformer(missing_value_replacement='mean', model_missing_values=True)
 
         # Run
         data = pd.Series([1, 2, np.nan])
-        transformer.fit(data)
+        transformer.fit(data, 'column')
 
         # Assert
         assert transformer.nulls
-        assert transformer._null_column
-        assert transformer._fill_value == 1.5
+        assert transformer._model_missing_values
+        assert transformer._missing_value_replacement == 1.5
 
-    def test_fit_null_column_none_and_no_nulls(self):
+    def test_fit_model_missing_values_none_and_no_nulls(self):
         """Test fit when null column is none and there are NO nulls.
 
-        If there are no nulls in the data and null_column was given as None,
-        then the _null_column attribute should be set to False.
-        Also validate that the null attribute and the _fill_value attributes
+        If there are no nulls in the data and model_missing_values was given as None,
+        then the _model_missing_values attribute should be set to False.
+        Also validate that the null attribute and the _missing_value_replacement attributes
         are set accordingly.
 
         Setup:
@@ -286,125 +277,98 @@ class TestNullTransformer:
             - pd.Series of strings that contains no nulls.
 
         Expected Side Effects:
-            - the null_column attribute should be set to False.
+            - the model_missing_values attribute should be set to False.
             - the nulls attribute should be set to False.
-            - the fill_value should be set to the mode of the given strings.
+            - the missing_value_replacement should be set to ``np.nan``, default.
         """
         # Setup
         transformer = NullTransformer()
 
         # Run
         data = pd.Series(['a', 'b', 'b'])
-        transformer.fit(data)
+        transformer.fit(data, 'column')
 
         # Assert
         assert not transformer.nulls
-        assert not transformer._null_column
-        assert transformer._fill_value == 'b'
+        assert not transformer._model_missing_values
+        assert transformer._missing_value_replacement is np.nan
 
-    def test_fit_null_column_not_none(self):
+    def test_fit_model_missing_values_not_none(self):
         """Test fit when null column is set to True/False.
 
-        If null_column is set to True or False, the _null_column should
+        If model_missing_values is set to True or False, the _model_missing_values should
         get that value regardless of whether there are nulls or not.
 
         Notice that this test covers 4 scenarios at once.
 
         Setup:
-            - 4 NullTransformer intances, 2 of them passing False for the null_column
+            - 4 NullTransformer intances, 2 of them passing False for the model_missing_values
               and 2 of them passing True.
 
         Input:
             - 2 pd.Series, one containing nulls and the other not containing nulls.
 
         Expected Side Effects:
-            - the _null_column attribute should be set to True or False as indicated
+            - the _model_missing_values attribute should be set to True or False as indicated
               in the Transformer creation.
             - the nulls attribute should be True or False depending on whether
               the input data contains nulls or not.
         """
         # Setup
-        null_column_false_nulls = NullTransformer(null_column=False)
-        null_column_false_no_nulls = NullTransformer(null_column=False)
-        null_column_true_nulls = NullTransformer(null_column=True)
-        null_column_true_no_nulls = NullTransformer(null_column=True)
+        model_missing_values_false_nulls = NullTransformer(
+            missing_value_replacement='mode',
+            model_missing_values=False
+        )
+        model_missing_values_false_no_nulls = NullTransformer(
+            missing_value_replacement='mode',
+            model_missing_values=False
+        )
+        model_missing_values_true_nulls = NullTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
+        model_missing_values_true_no_nulls = NullTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
         nulls_str = pd.Series(['a', 'b', 'b', np.nan])
         no_nulls_str = pd.Series(['a', 'b', 'b', 'c'])
         nulls_int = pd.Series([1, 2, 3, np.nan])
         no_nulls_int = pd.Series([1, 2, 3, 4])
 
         # Run
-        null_column_false_nulls.fit(nulls_str)
-        null_column_false_no_nulls.fit(no_nulls_str)
-        null_column_true_nulls.fit(nulls_int)
-        null_column_true_no_nulls.fit(no_nulls_int)
+        model_missing_values_false_nulls.fit(nulls_str, 'column')
+        model_missing_values_false_no_nulls.fit(no_nulls_str, 'column')
+        model_missing_values_true_nulls.fit(nulls_int, 'column')
+        model_missing_values_true_no_nulls.fit(no_nulls_int, 'column')
 
         # Assert
-        assert not null_column_false_nulls._null_column
-        assert null_column_false_nulls.nulls
-        assert null_column_false_nulls._fill_value == 'b'
+        assert not model_missing_values_false_nulls._model_missing_values
+        assert model_missing_values_false_nulls.nulls
+        assert model_missing_values_false_nulls._missing_value_replacement == 'b'
 
-        assert not null_column_false_no_nulls._null_column
-        assert not null_column_false_no_nulls.nulls
-        assert null_column_false_no_nulls._fill_value == 'b'
+        assert not model_missing_values_false_no_nulls._model_missing_values
+        assert not model_missing_values_false_no_nulls.nulls
+        assert model_missing_values_false_no_nulls._missing_value_replacement == 'b'
 
-        assert null_column_true_nulls._null_column
-        assert null_column_true_nulls.nulls
-        assert null_column_true_nulls._fill_value == 2
+        assert model_missing_values_true_nulls._model_missing_values
+        assert model_missing_values_true_nulls.nulls
+        assert model_missing_values_true_nulls._missing_value_replacement == 2
 
-        assert null_column_true_no_nulls._null_column
-        assert not null_column_true_no_nulls.nulls
-        assert null_column_true_no_nulls._fill_value == 2.5
+        assert not model_missing_values_true_no_nulls._model_missing_values
+        assert not model_missing_values_true_no_nulls.nulls
+        assert model_missing_values_true_no_nulls._missing_value_replacement == 2.5
 
-    def test_transform__null_column_false_copy_false(self):
-        """Test transform when _null_column is False and copy is False.
+    def test_transform__model_missing_values_true(self):
+        """Test transform when _model_missing_values.
 
-        When the _null_column is false, the nulls should be replaced
-        by the _fill_value.
-        When copy is False, the original data is affected.
-
-        Setup:
-            - NullTransformer instance with _null_column set to False,
-              _fill_value set to a scalar value, and copy set to False.
-
-        Input:
-            - A pd.Series of integers with nulls.
-
-        Expected Output:
-            - Same data as the input, replacing the nulls with the
-              scalar value.
-
-        Expected Side Effects:
-            - The input data has the null values replaced.
-        """
-        # Setup
-        transformer = NullTransformer()
-        transformer._null_column = False
-        transformer._fill_value = 3
-        transformer.copy = False
-        input_data = pd.Series([1, 2, np.nan])
-
-        # Run
-        output = transformer.transform(input_data)
-
-        # Assert
-        expected_output = np.array([1, 2, 3])
-        np.testing.assert_equal(expected_output, output)
-
-        modified_input_data = pd.Series([1, 2, 3], dtype=np.float64)
-        pd.testing.assert_series_equal(modified_input_data, input_data)
-
-    def test_transform__null_column_true_copy_false(self):
-        """Test transform when _null_column and copy is False.
-
-        When _null_column, the nulls should be replaced
-        by the _fill_value and another column flagging the nulls
+        When _model_missing_values, the nulls should be replaced
+        by the _missing_value_replacement and another column flagging the nulls
         should be created.
-        When copy is False, the original data is affected.
 
         Setup:
-            - NullTransformer instance with _null_column set to True,
-              _fill_value set to a scalar value, and copy set to False.
+            - NullTransformer instance with _model_missing_values set to True,
+              _missing_value_replacement set to a scalar value.
 
         Input:
             - A pd.Series of strings with nulls.
@@ -419,9 +383,8 @@ class TestNullTransformer:
         # Setup
         transformer = NullTransformer()
         transformer.nulls = False
-        transformer._null_column = True
-        transformer._fill_value = 'c'
-        transformer.copy = False
+        transformer._model_missing_values = True
+        transformer._missing_value_replacement = 'c'
         input_data = pd.Series(['a', 'b', np.nan])
 
         # Run
@@ -435,19 +398,15 @@ class TestNullTransformer:
         ], dtype=object)
         np.testing.assert_equal(expected_output, output)
 
-        modified_input_data = pd.Series(['a', 'b', 'c'])
-        pd.testing.assert_series_equal(modified_input_data, input_data)
+    def test_transform__model_missing_values_false(self):
+        """Test transform when _model_missing_values is False.
 
-    def test_transform__null_column_false_copy_true(self):
-        """Test transform when _null_column is False and copy.
-
-        When the _null_column is false, the nulls should be replaced
-        by the _fill_value.
-        When copy, the original data is not affected.
+        When the _model_missing_values is false, the nulls should be replaced
+        by the _missing_value_replacement.
 
         Setup:
-            - NullTransformer instance with _null_column set to False,
-              _fill_value set to a scalar value, and copy set to True.
+            - NullTransformer instance with _model_missing_values set to False,
+              _missing_value_replacement set to a scalar value.
 
         Input:
             - A pd.Series of integers with nulls.
@@ -461,9 +420,8 @@ class TestNullTransformer:
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = False
-        transformer._fill_value = 3
-        transformer.copy = True
+        transformer._model_missing_values = False
+        transformer._missing_value_replacement = 3
         input_data = pd.Series([1, 2, np.nan])
 
         # Run
@@ -476,62 +434,18 @@ class TestNullTransformer:
         modified_input_data = pd.Series([1, 2, np.nan])
         pd.testing.assert_series_equal(modified_input_data, input_data)
 
-    def test_transform__null_column_true_copy_true(self):
-        """Test transform when _null_column and copy.
-
-        When _null_column, the nulls should be replaced
-        by the _fill_value and another column flagging the nulls
-        should be created.
-        When copy, the original data is not affected.
-
-        Setup:
-            - NullTransformer instance with _null_column set to True,
-              _fill_value set to a scalar value, and copy set to True.
-
-        Input:
-            - A pd.Series of strings with nulls.
-
-        Expected Output:
-            - Exactly the same as the input, replacing the nulls with the
-              scalar value.
-
-        Expected Side Effects:
-            - The input data has not been modified.
-        """
-        # Setup
-        transformer = NullTransformer()
-        transformer.nulls = False
-        transformer._null_column = True
-        transformer._fill_value = 'c'
-        transformer.copy = True
-        input_data = pd.Series(['a', 'b', np.nan])
-
-        # Run
-        output = transformer.transform(input_data)
-
-        # Assert
-        expected_output = np.array([
-            ['a', 0.0],
-            ['b', 0.0],
-            ['c', 1.0],
-        ], dtype=object)
-        np.testing.assert_equal(expected_output, output)
-
-        modified_input_data = pd.Series(['a', 'b', np.nan])
-        pd.testing.assert_series_equal(modified_input_data, input_data)
-
     def test_transform__irreversible_warning(self):
-        """Test transform when _null_column is False and fill_value is in data.
+        """Test transform when _model_missing_values is False and missing_value_replacement is in data.
 
-        When _null_column is False, and the fill_value exists in the data
+        When _model_missing_values is False, and the missing_value_replacement exists in the data
         before transforming, a warning is raised.
 
         Setup:
-            - NullTransformer instance with _null_column set to False
-              and _fill_value set to a scalar value.
+            - NullTransformer instance with _model_missing_values set to False
+              and _missing_value_replacement set to a scalar value.
 
         Input:
-            - A pd.Series of strings with nulls, containing the fill_value.
+            - A pd.Series of strings with nulls, containing the missing_value_replacement.
 
         Expected Output:
             - Exactly the same as the input, replacing the nulls with the
@@ -542,8 +456,8 @@ class TestNullTransformer:
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = False
-        transformer._fill_value = 'b'
+        transformer._model_missing_values = False
+        transformer._missing_value_replacement = 'b'
         input_data = pd.Series(['a', 'b', np.nan])
 
         # Run
@@ -554,62 +468,16 @@ class TestNullTransformer:
         expected_output = np.array(['a', 'b', 'b'])
         np.testing.assert_equal(expected_output, output)
 
-    def test_reverse_transform__null_column_true_nulls_true_copy_true(self):
-        """Test reverse_transform when _null_column, nulls and copy are True.
+    def test_reverse_transform__model_missing_values_true_nulls_true(self):
+        """Test reverse_transform when _model_missing_values and nulls are True.
 
-        When _null_column and nulls attributes are both True, the second column
+        When _model_missing_values and nulls attributes are both True, the second column
         in the input data should be used to decide which values to replace
         with nan, by selecting the rows where the null column value is > 0.5.
-        If copy, the input data should not be modified.
 
         Setup:
-            - NullTransformer instance with _null_column, nulls and copy
+            - NullTransformer instance with _model_missing_values and nulls
               attributes set to True.
-
-        Input:
-            - 2d numpy array with variate float values.
-
-        Expected Output:
-            - pd.Series containing the first column from the input data
-              with the values indicated by the first column replaced by nans.
-
-        Expected Side Effects:
-            - the input data should not have been modified.
-        """
-        # Setup
-        transformer = NullTransformer()
-        transformer._null_column = True
-        transformer.nulls = True
-        transformer.copy = True
-        input_data = np.array([
-            [0.0, 0.0],
-            [0.2, 0.2],
-            [0.4, 0.4],
-            [0.6, 0.6],
-            [0.8, 0.8],
-        ])
-        input_data_copy = input_data.copy()
-
-        # Run
-        output = transformer.reverse_transform(input_data)
-
-        # Assert
-        expected_output = pd.Series([0.0, 0.2, 0.4, np.nan, np.nan])
-        pd.testing.assert_series_equal(expected_output, output)
-
-        np.testing.assert_equal(input_data, input_data_copy)
-
-    def test_reverse_transform__null_column_true_nulls_true_copy_false(self):
-        """Test reverse_transform when _null_column and nulls are True, and copy is False.
-
-        When _null_column and nulls attributes are both True, the second column
-        in the input data should be used to decide which values to replace
-        with nan, by selecting the rows where the null column value is > 0.5.
-        If copy is False, the input data should be modified in place.
-
-        Setup:
-            - NullTransformer instance with _null_column and nulls
-              attributes set to True, and copy set to False.
 
         Input:
             - 2d numpy array with variate float values.
@@ -623,9 +491,8 @@ class TestNullTransformer:
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = True
+        transformer._model_missing_values = True
         transformer.nulls = True
-        transformer.copy = False
         input_data = np.array([
             [0.0, 0.0],
             [0.2, 0.2],
@@ -641,24 +508,15 @@ class TestNullTransformer:
         expected_output = pd.Series([0.0, 0.2, 0.4, np.nan, np.nan])
         pd.testing.assert_series_equal(expected_output, output)
 
-        modified_input_data = np.array([
-            [0.0, 0.0],
-            [0.2, 0.2],
-            [0.4, 0.4],
-            [np.nan, 0.6],
-            [np.nan, 0.8],
-        ])
-        np.testing.assert_equal(modified_input_data, input_data)
+    def test_reverse_transform__model_missing_values_true_nulls_false(self):
+        """Test reverse_transform when _model_missing_values and nulls is False.
 
-    def test_reverse_transform__null_column_true_nulls_false(self):
-        """Test reverse_transform when _null_column and nulls is False.
-
-        When _null_column but nulls are False, the second column of the
+        When _model_missing_values but nulls are False, the second column of the
         input data must be dropped and the first one returned as a Series without
         having been modified.
 
         Setup:
-            - NullTransformer instance with _null_column set to True and nulls
+            - NullTransformer instance with _model_missing_values set to True and nulls
               attribute set to False
 
         Input:
@@ -669,7 +527,7 @@ class TestNullTransformer:
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = True
+        transformer._model_missing_values = True
         transformer.nulls = False
         input_data = np.array([
             [0.0, 0.0],
@@ -686,30 +544,30 @@ class TestNullTransformer:
         expected_output = pd.Series([0.0, 0.2, 0.4, 0.6, 0.8])
         pd.testing.assert_series_equal(expected_output, output)
 
-    def test_reverse_transform__null_column_false_nulls_true(self):
-        """Test reverse_transform when _null_column is False and nulls.
+    def test_reverse_transform__model_missing_values_false_nulls_true(self):
+        """Test reverse_transform when _model_missing_values is False and nulls.
 
-        When _null_column is False and the nulls attribute, the
-        values in the input data that match the _fill_value attribute are
+        When _model_missing_values is False and the nulls attribute, the
+        values in the input data that match the _missing_value_replacement attribute are
         replaced by nans.
 
         Setup:
-            - NullTransformer instance with _null_column set to False and nulls
-              attribute set to True, and with the _fill_value set to a scalar.
+            - NullTransformer instance with _model_missing_values set to False and nulls
+              attribute set to True, and with the _missing_value_replacement set to a scalar.
 
         Input:
-            - 1d numpy array with variate float values, containing the _fill_value
+            - 1d numpy array with variate float values, containing the _missing_value_replacement
               among them.
 
         Expected Output:
             - pd.Series containing the same data as input, with the values that
-              match the _fill_value replaced by nans.
+              match the _missing_value_replacement replaced by nans.
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = False
+        transformer._model_missing_values = False
         transformer.nulls = True
-        transformer._fill_value = 0.4
+        transformer._missing_value_replacement = 0.4
         input_data = np.array([0.0, 0.2, 0.4, 0.6])
 
         # Run
@@ -719,18 +577,18 @@ class TestNullTransformer:
         expected_output = pd.Series([0.0, 0.2, np.nan, 0.6])
         pd.testing.assert_series_equal(expected_output, output)
 
-    def test_reverse_transform__null_column_false_nulls_false(self):
-        """Test reverse_transform when _null_column is False and nulls.
+    def test_reverse_transform__model_missing_values_false_nulls_false(self):
+        """Test reverse_transform when _model_missing_values is False and nulls.
 
-        When _null_column is False and the nulls attribute is also False, the
+        When _model_missing_values is False and the nulls attribute is also False, the
         input data is not modified at all.
 
         Setup:
-            - NullTransformer instance with _null_column and nulls attributes
-              set to False, and the _fill_value set to a scalar value.
+            - NullTransformer instance with _model_missing_values and nulls attributes
+              set to False, and the _missing_value_replacement set to a scalar value.
 
         Input:
-            - 1d numpy array with variate float values, containing the _fill_value
+            - 1d numpy array with variate float values, containing the _missing_value_replacement
               among them.
 
         Expected Output:
@@ -738,9 +596,9 @@ class TestNullTransformer:
         """
         # Setup
         transformer = NullTransformer()
-        transformer._null_column = False
+        transformer._model_missing_values = False
         transformer.nulls = False
-        transformer._fill_value = 0.4
+        transformer._missing_value_replacement = 0.4
         input_data = np.array([0.0, 0.2, 0.4, 0.6])
 
         # Run

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -26,7 +26,7 @@ class TestNullTransformer:
         transformer = NullTransformer()
 
         # Assert
-        assert transformer.missing_value_replacement is None
+        assert transformer._missing_value_replacement is None
         assert not transformer._model_missing_values
 
     def test___init__not_default(self):
@@ -45,7 +45,7 @@ class TestNullTransformer:
         transformer = NullTransformer('a_missing_value_replacement', False)
 
         # Assert
-        assert transformer.missing_value_replacement == 'a_missing_value_replacement'
+        assert transformer._missing_value_replacement == 'a_missing_value_replacement'
         assert not transformer._model_missing_values
 
     def test_models_missing_values(self):
@@ -291,7 +291,7 @@ class TestNullTransformer:
         # Assert
         assert not transformer.nulls
         assert not transformer._model_missing_values
-        assert transformer._missing_value_replacement is np.nan
+        assert transformer._missing_value_replacement is None
 
     def test_fit_model_missing_values_not_none(self):
         """Test fit when null column is set to True/False.

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -48,8 +48,8 @@ class TestNullTransformer:
         assert transformer.missing_value_replacement == 'a_missing_value_replacement'
         assert not transformer.model_missing_values
 
-    def test_creates_model_missing_values(self):
-        """Test the creates_model_missing_values method.
+    def test_models_missing_values(self):
+        """Test the models_missing_values method.
 
         If the `model_missing_values` attributes evalutes to True, the
         `create_model_missing_values` method should return the same value.
@@ -65,10 +65,10 @@ class TestNullTransformer:
         transformer._model_missing_values = True
 
         # Run
-        creates_model_missing_values = transformer.creates_model_missing_values()
+        models_missing_values = transformer.models_missing_values()
 
         # Assert
-        assert creates_model_missing_values
+        assert models_missing_values
 
     def test__get_missing_value_replacement_scalar(self):
         """Test _get_missing_value_replacement when a scalar value is passed.
@@ -255,7 +255,7 @@ class TestNullTransformer:
 
         # Run
         data = pd.Series([1, 2, np.nan])
-        transformer.fit(data, 'column')
+        transformer.fit(data)
 
         # Assert
         assert transformer.nulls
@@ -286,7 +286,7 @@ class TestNullTransformer:
 
         # Run
         data = pd.Series(['a', 'b', 'b'])
-        transformer.fit(data, 'column')
+        transformer.fit(data)
 
         # Assert
         assert not transformer.nulls
@@ -337,10 +337,10 @@ class TestNullTransformer:
         no_nulls_int = pd.Series([1, 2, 3, 4])
 
         # Run
-        model_missing_values_false_nulls.fit(nulls_str, 'column')
-        model_missing_values_false_no_nulls.fit(no_nulls_str, 'column')
-        model_missing_values_true_nulls.fit(nulls_int, 'column')
-        model_missing_values_true_no_nulls.fit(no_nulls_int, 'column')
+        model_missing_values_false_nulls.fit(nulls_str)
+        model_missing_values_false_no_nulls.fit(no_nulls_str)
+        model_missing_values_true_nulls.fit(nulls_int)
+        model_missing_values_true_no_nulls.fit(no_nulls_int)
 
         # Assert
         assert not model_missing_values_false_nulls._model_missing_values

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -1139,6 +1139,41 @@ class TestGaussianCopulaTransformer:
             np.array([0.0, 0.5, 1.0])
         )
 
+    def test__fit_model_missing_values(self):
+        """Test the ``_fit`` method.
+
+        Validate that ``_fit`` calls ``_get_univariate``.
+
+        Setup:
+            - create an instance of the ``GaussianCopulaTransformer``.
+            - mock the  ``_get_univariate`` method.
+
+        Input:
+            - a pandas series of float values.
+
+        Side effect:
+            - call the `_get_univariate`` method.
+        """
+        # Setup
+        data = pd.Series([0.0, np.nan, 1.0])
+        ct = GaussianCopulaTransformer(
+            missing_value_replacement='mean',
+            model_missing_values=True
+        )
+        ct._get_univariate = Mock()
+        ct.columns = ['column']
+
+        # Run
+        ct._fit(data)
+
+        # Assert
+        ct._get_univariate.return_value.fit.assert_called_once()
+        call_value = ct._get_univariate.return_value.fit.call_args_list[0]
+        np.testing.assert_array_equal(
+            call_value[0][0],
+            np.array([0.0, 0.5, 1.0])
+        )
+
     def test__copula_transform(self):
         """Test the ``_copula_transform`` method.
 

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -227,7 +227,7 @@ class TestNumericalTransformer(TestCase):
 
         # Asserts
         expected = 'missing_value_replacement'
-        assert transformer.null_transformer.missing_value_replacement == expected
+        assert transformer.null_transformer._missing_value_replacement == expected
         expect_dtype = float
         assert transformer._dtype == expect_dtype
 
@@ -1340,7 +1340,7 @@ class TestGaussianCopulaTransformer:
 
 class TestBayesGMMTransformer(TestCase):
 
-    def test_get_output_types_model_missing_values_created(self):
+    def test_get_output_types_model_missing_values_column_created(self):
         """Test the ``get_output_types`` method when a null column is created.
 
         When a null column is created, this method should apply the ``_add_prefix``

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -16,7 +16,11 @@ class TestNumericalTransformer(TestCase):
 
     def test___init__super_attrs(self):
         """super() arguments are properly passed and set as attributes."""
-        nt = NumericalTransformer(dtype='int', missing_value_replacement='mode', model_missing_values=False)
+        nt = NumericalTransformer(
+            dtype='int',
+            missing_value_replacement='mode',
+            model_missing_values=False
+        )
 
         assert nt.dtype == 'int'
         assert nt.missing_value_replacement == 'mode'
@@ -129,7 +133,8 @@ class TestNumericalTransformer(TestCase):
         should be returned.
 
         Input:
-        - An array that contains floats with a maximum of 3 decimals and a missing_value_replacement.
+        - An array that contains floats with a maximum of 3 decimals and a
+          missing_value_replacement.
         Output:
         - 3
         """
@@ -885,7 +890,10 @@ class TestNumericalTransformer(TestCase):
         expected_data = np.array([-300, -300, np.nan, -250, 0, np.nan, 400, 400])
 
         # Run
-        transformer = NumericalTransformer(dtype=float, missing_value_replacement='missing_value_replacement')
+        transformer = NumericalTransformer(
+            dtype=float,
+            missing_value_replacement='missing_value_replacement'
+        )
         transformer._max_value = 400
         transformer._min_value = -300
         transformer.null_transformer = Mock()
@@ -902,7 +910,11 @@ class TestGaussianCopulaTransformer:
 
     def test___init__super_attrs(self):
         """super() arguments are properly passed and set as attributes."""
-        ct = GaussianCopulaTransformer(dtype='int', missing_value_replacement='mode', model_missing_values=False)
+        ct = GaussianCopulaTransformer(
+            dtype='int',
+            missing_value_replacement='mode',
+            model_missing_values=False
+        )
 
         assert ct.dtype == 'int'
         assert ct.missing_value_replacement == 'mode'
@@ -1158,7 +1170,8 @@ class TestGaussianCopulaTransformer:
     def test__transform(self):
         """Test the ``_transform`` method.
 
-        Validate that ``_transform`` produces the correct values when ``model_missing_values`` is True.
+        Validate that ``_transform`` produces the correct values when ``model_missing_values``
+        is True.
 
         Setup:
             - create an instance of the ``GaussianCopulaTransformer``, where:
@@ -1193,7 +1206,8 @@ class TestGaussianCopulaTransformer:
     def test__transform_model_missing_values_none(self):
         """Test the ``_transform`` method.
 
-        Validate that ``_transform`` produces the correct values when ``model_missing_values`` is None.
+        Validate that ``_transform`` produces the correct values when ``model_missing_values``
+        is None.
 
         Setup:
             - create an instance of the ``GaussianCopulaTransformer``, where:
@@ -1671,8 +1685,8 @@ class TestBayesGMMTransformer(TestCase):
             - create an instance of the ``BayesGMMTransformer`` where the ``output_columns``
             is a list of two columns.
             - mock the `_reverse_transform_helper` with the appropriate return value.
-            - set ``null_transformer`` to ``NullTransformer`` with ``model_missing_values`` as True,
-            then fit it to a pandas Series.
+            - set ``null_transformer`` to ``NullTransformer`` with ``model_missing_values`` as
+              True, then fit it to a pandas Series.
 
         Input:
             - a numpy ndarray containing transformed ``np.nan`` values.

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -221,7 +221,6 @@ class TestNumericalTransformer(TestCase):
             dtype=float,
             missing_value_replacement='missing_value_replacement'
         )
-        transformer.columns = ['column']
 
         # Run
         transformer._fit(data)
@@ -253,7 +252,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding=None
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -282,7 +280,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding=expected_digits
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -310,7 +307,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -340,7 +336,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -371,7 +366,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -400,7 +394,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -427,7 +420,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -455,7 +447,6 @@ class TestNumericalTransformer(TestCase):
             missing_value_replacement='missing_value_replacement',
             rounding='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -483,7 +474,6 @@ class TestNumericalTransformer(TestCase):
             min_value=None,
             max_value=None
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -511,7 +501,6 @@ class TestNumericalTransformer(TestCase):
             min_value=1,
             max_value=10
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -540,7 +529,6 @@ class TestNumericalTransformer(TestCase):
             min_value='auto',
             max_value='auto'
         )
-        transformer.columns = ['column']
         transformer._fit(data)
 
         # Asserts
@@ -1126,7 +1114,6 @@ class TestGaussianCopulaTransformer:
         data = pd.Series([0.0, np.nan, 1.0])
         ct = GaussianCopulaTransformer(missing_value_replacement='mean')
         ct._get_univariate = Mock()
-        ct.columns = ['column']
 
         # Run
         ct._fit(data)
@@ -1161,7 +1148,6 @@ class TestGaussianCopulaTransformer:
             model_missing_values=True
         )
         ct._get_univariate = Mock()
-        ct.columns = ['column']
 
         # Run
         ct._fit(data)
@@ -1226,7 +1212,7 @@ class TestGaussianCopulaTransformer:
         ct._univariate = Mock()
         ct._univariate.cdf.return_value = np.array([0.25, 0.5, 0.75, 0.5])
         ct.null_transformer = NullTransformer(None, model_missing_values=True)
-        ct.null_transformer.fit(data, 'column')
+        ct.null_transformer.fit(data)
 
         # Run
         transformed_data = ct._transform(data)
@@ -1262,12 +1248,11 @@ class TestGaussianCopulaTransformer:
         ])
         ct = GaussianCopulaTransformer()
         ct._univariate = Mock()
-        ct.columns = ['column']
         ct._univariate.cdf.return_value = np.array([0.25, 0.5, 0.75, 0.5])
         ct.null_transformer = NullTransformer('mean', model_missing_values=None)
 
         # Run
-        ct.null_transformer.fit(data, 'column')
+        ct.null_transformer.fit(data)
         transformed_data = ct._transform(data)
 
         # Assert
@@ -1309,7 +1294,7 @@ class TestGaussianCopulaTransformer:
         )
 
         # Run
-        ct.null_transformer.fit(expected, 'column')
+        ct.null_transformer.fit(expected)
         transformed_data = ct._reverse_transform(data)
 
         # Assert
@@ -1346,7 +1331,7 @@ class TestGaussianCopulaTransformer:
         ct.null_transformer = NullTransformer(None, model_missing_values=None)
 
         # Run
-        ct.null_transformer.fit(expected, 'column')
+        ct.null_transformer.fit(expected)
         transformed_data = ct._reverse_transform(data)
 
         # Assert
@@ -1417,7 +1402,6 @@ class TestBayesGMMTransformer(TestCase):
         bgm_instance.weights_ = np.array([10.0, 5.0, 0.0])
         transformer = BayesGMMTransformer(max_clusters=10, weight_threshold=0.005)
         data = pd.Series(np.random.random(size=100))
-        transformer.columns = ['column']
 
         # Run
         transformer._fit(data)
@@ -1454,7 +1438,6 @@ class TestBayesGMMTransformer(TestCase):
             weight_threshold=0.005,
             model_missing_values=True
         )
-        transformer.columns = ['column']
 
         data = pd.Series(np.random.random(size=100))
         mask = np.random.choice([1, 0], data.shape, p=[.1, .9]).astype(bool)
@@ -1466,7 +1449,7 @@ class TestBayesGMMTransformer(TestCase):
         # Asserts
         assert transformer._bgm_transformer == bgm_instance
         assert transformer.valid_component_indicator.sum() == 2
-        assert transformer.null_transformer.creates_model_missing_values()
+        assert transformer.null_transformer.models_missing_values()
 
     def test__transform(self):
         """Test ``_transform``.
@@ -1594,7 +1577,7 @@ class TestBayesGMMTransformer(TestCase):
         data = pd.Series([0.01, np.nan, -0.01, -0.01, 0.0, 0.99, 0.97, np.nan, np.nan, 0.97])
 
         # Run
-        transformer.null_transformer.fit(data, 'column')
+        transformer.null_transformer.fit(data)
         output = transformer._transform(data)
 
         # Asserts
@@ -1746,7 +1729,7 @@ class TestBayesGMMTransformer(TestCase):
         ])
 
         transformer.null_transformer = NullTransformer('mean', model_missing_values=True)
-        transformer.null_transformer.fit(pd.Series([0, np.nan]), 'column')
+        transformer.null_transformer.fit(pd.Series([0, np.nan]))
 
         data = np.array([
             [-0.033, -0.046, -0.058, -0.058, -0.046, 0.134, 0.122, -0.046, -0.046, 0.122],

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -183,12 +183,12 @@ class TestNumericalTransformer(TestCase):
         assert output == -1
 
     def test__learn_rounding_digits_all_missing_value_replacements(self):
-        """Test the _learn_rounding_digits method with data that is all missing_value_replacements.
+        """Test the _learn_rounding_digits method with data that is all NaNs.
 
-        If the data is all missing_value_replacements, expect that the output is None.
+        If the data is all NaNs, expect that the output is None.
 
         Input:
-        - An array of missing_value_replacements.
+        - An array of NaN.
         Output:
         - None
         """
@@ -649,7 +649,7 @@ class TestNumericalTransformer(TestCase):
         - 2d Array of multiple float values with decimals and a column setting at least 1 null.
         Output:
         - First column of the input array rounded, replacing the indicated value with a
-          ``missing_value_replacement``, and kept as float values.
+          ``NaN``, and kept as float values.
         """
         # Setup
         data = np.array([

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -134,7 +134,7 @@ class TestNumericalTransformer(TestCase):
 
         Input:
         - An array that contains floats with a maximum of 3 decimals and a
-          missing_value_replacement.
+          NaN.
         Output:
         - 3
         """

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -153,7 +153,7 @@ class TestNumericalTransformer(TestCase):
 
         Input:
         - An array that contains floats that are multiples of powers of 10, 100 and 1000
-          and a missing_value_replacement.
+          and a NaN.
         Output:
         - -1
         """
@@ -172,7 +172,7 @@ class TestNumericalTransformer(TestCase):
 
         Input:
         - An array that contains integers that are multiples of powers of 10, 100 and 1000
-          and a missing_value_replacement.
+          and a NaN.
         Output:
         - -1
         """
@@ -649,7 +649,7 @@ class TestNumericalTransformer(TestCase):
         - 2d Array of multiple float values with decimals and a column setting at least 1 null.
         Output:
         - First column of the input array rounded, replacing the indicated value with a
-          missing_value_replacement, and kept as float values.
+          ``missing_value_replacement``, and kept as float values.
         """
         # Setup
         data = np.array([
@@ -1228,7 +1228,7 @@ class TestGaussianCopulaTransformer:
         """Test the ``_transform`` method.
 
         Validate that ``_transform`` produces the correct values when ``model_missing_values``
-        is None.
+        is ``False``.
 
         Setup:
             - create an instance of the ``GaussianCopulaTransformer``, where:
@@ -1249,7 +1249,7 @@ class TestGaussianCopulaTransformer:
         ct = GaussianCopulaTransformer()
         ct._univariate = Mock()
         ct._univariate.cdf.return_value = np.array([0.25, 0.5, 0.75, 0.5])
-        ct.null_transformer = NullTransformer('mean', model_missing_values=None)
+        ct.null_transformer = NullTransformer('mean', model_missing_values=False)
 
         # Run
         ct.null_transformer.fit(data)
@@ -1328,7 +1328,7 @@ class TestGaussianCopulaTransformer:
         ct = GaussianCopulaTransformer()
         ct._univariate = Mock()
         ct._univariate.ppf.return_value = np.array([0.0, 1.0, 2.0, 1.0])
-        ct.null_transformer = NullTransformer(None, model_missing_values=None)
+        ct.null_transformer = NullTransformer(None, model_missing_values=False)
 
         # Run
         ct.null_transformer.fit(expected)


### PR DESCRIPTION
### NullTransformer
With the current `PR` the `NullTransformer` contains the following changes:
* Always works with a copy of the data (no changes occur to the original data).
* Adapt unit tests and integration tests.
* New user friendly names for the fill value / nan and null column:
    * `fill_value` or `nan` becomes -> `missing_value_replacement`.
    * `null_column` becomes -> `model_missing_values`.

#### `missing_value_replacement`
By default this value will be `None` which will not replace the values. From python perspective this will return `np.nan` which should be the representation of `Null`.

The second strategy is the user specifying a string `mode` or `mean` , which will use the `mode` of the data or the `mean` value (if possible) as a replacement of the `null` values that are in the data.

The third strategy is the user specifying a value for it which will be used to fill the null values with.

#### `model_missing_values`
By default this value will be `False`. If set to `True` it will generate a new column representing if there was a missing value or not. In the case that the data had no missing values this column will not be generated.




Resolves #372 , #362 , #376 