### PR TITLE
Support dropping column transformer

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -52,7 +52,7 @@ class BaseTransformer:
 
     def _add_prefix(self, dictionary):
         if not dictionary:
-            return None
+            return {}
 
         output = {}
         for output_columns, output_type in dictionary.items():
@@ -67,7 +67,7 @@ class BaseTransformer:
             dict:
                 Mapping from the transformed column names to the produced data types.
         """
-        return self._add_prefix(self.OUTPUT_TYPES) if self.OUTPUT_TYPES else {}
+        return self._add_prefix(self.OUTPUT_TYPES)
 
     def is_transform_deterministic(self):
         """Return whether the transform is deterministic.

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -67,7 +67,7 @@ class BaseTransformer:
             dict:
                 Mapping from the transformed column names to the produced data types.
         """
-        return self._add_prefix(self.OUTPUT_TYPES)
+        return self._add_prefix(self.OUTPUT_TYPES) if self.OUTPUT_TYPES else dict()
 
     def is_transform_deterministic(self):
         """Return whether the transform is deterministic.
@@ -147,9 +147,9 @@ class BaseTransformer:
         if isinstance(columns_data, (pd.DataFrame, pd.Series)):
             columns_data.index = data.index
 
-        if len(columns_data.shape) == 1:
+        if columns_data is not None and len(columns_data.shape) == 1:
             data[columns[0]] = columns_data
-        else:
+        elif columns_data is not None:
             data[columns] = columns_data
 
     def _build_output_columns(self, data):

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -144,12 +144,15 @@ class BaseTransformer:
 
     @staticmethod
     def _set_columns_data(data, columns_data, columns):
+        if columns_data is None:
+            return
+
         if isinstance(columns_data, (pd.DataFrame, pd.Series)):
             columns_data.index = data.index
 
-        if columns_data is not None and len(columns_data.shape) == 1:
+        if len(columns_data.shape) == 1:
             data[columns[0]] = columns_data
-        elif columns_data is not None:
+        else:
             data[columns] = columns_data
 
     def _build_output_columns(self, data):

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -121,7 +121,7 @@ class BaseTransformer:
             list:
                 Names of columns created during ``transform``.
         """
-        return [f'{self.column_prefix}.{output}' for output in self.OUTPUT_TYPES]
+        return list(self.get_output_types())
 
     def _store_columns(self, columns, data):
         if isinstance(columns, tuple) and columns not in data:

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -67,7 +67,7 @@ class BaseTransformer:
             dict:
                 Mapping from the transformed column names to the produced data types.
         """
-        return self._add_prefix(self.OUTPUT_TYPES) if self.OUTPUT_TYPES else dict()
+        return self._add_prefix(self.OUTPUT_TYPES) if self.OUTPUT_TYPES else {}
 
     def is_transform_deterministic(self):
         """Return whether the transform is deterministic.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "numpy>=1.18.0,<1.20.0;python_version<'3.7'",
     "numpy>=1.20.0,<2;python_version>='3.7'",
     'pandas>=1.1.3,<2',
-    'scipy>=1.5.4,<2',
+    'scipy>=1.5.4,<1.8',
     'psutil>=5.7,<6',
     'scikit-learn>=0.24,<2',
     'pyyaml>=5.4.1,<6'

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -78,7 +78,7 @@ class TestBaseTransformer:
         output = base_transformer._add_prefix(dictionary)
 
         # Assert
-        assert output is None
+        assert output == {}
 
     def test__add_prefix_dictionary(self):
         """Test the ``_add_prefix`` method when passed a dictionary.

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -148,6 +148,21 @@ class TestBaseTransformer:
         }
         assert output == expected
 
+    def test_get_output_types_none(self):
+        """Test the ``get_output_types`` method.
+
+        Validate that a dict is returned even if ``OUTPUT_TYPES`` attribute is None.
+
+        Output:
+            - An empty ``dict``.
+        """
+        # Run
+        output = BaseTransformer().get_output_types()
+
+        # Assert
+        expected = {}
+        assert output == expected
+
     def test_get_input_columns(self):
         """Test the ``get_input_columns method.
 

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -650,6 +650,36 @@ class TestBaseTransformer:
         }, index=[2, 0, 1])
         pd.testing.assert_frame_equal(data, expected)
 
+    def test__set_columns_data_none(self):
+        """Test the ``_set_columns_data`` method.
+
+        The method should not change the ``data``.
+
+        Input:
+            - data will be a DataFrame with a non-sequential index.
+            - columns_data will be a ``None``.
+
+        Expected behavior:
+            - Data should not be changed.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6]
+        }, index=[2, 0, 1])
+        columns = ['c']
+        columns_data = None
+
+        # Run
+        BaseTransformer._set_columns_data(data, columns_data, columns)
+
+        # Assert
+        expected = pd.DataFrame({
+            'a': [1, 2, 3],
+            'b': [4, 5, 6],
+        }, index=[2, 0, 1])
+        pd.testing.assert_frame_equal(data, expected)
+
     def test__build_output_columns(self):
         """Test the ``_build_output_columns`` method.
 


### PR DESCRIPTION
Resolves #393

This pr also brings the following changes:
* Cap the `scipy` version to `<1.8` since it causes performance issues.
* Update `github-actions` setup to `v2` since `Windows` does not have `py36` env.
* Update the `get_output_columns` to call `get_output_types` which now always returns a dict (even if `OUTPUT_TYPES` is None). 