### PR TITLE
Fixing _unfit and get_transformer_tree_yaml bugs

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -160,6 +160,7 @@ class HyperTransformer:
 
     def _unfit(self):
         self._transformers_sequence = []
+        self._fitted_fields.clear()
         self._fitted = False
 
     def get_field_data_types(self):
@@ -318,7 +319,7 @@ class HyperTransformer:
             class_name = modified_tree[field]['transformer'].__class__.__name__
             modified_tree[field]['transformer'] = class_name
 
-        return yaml.safe_dump(modified_tree)
+        return yaml.safe_dump(dict(modified_tree))
 
     def _get_next_transformer(self, output_field, output_type, next_transformers):
         next_transformer = None

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
 
@@ -80,6 +81,7 @@ class TestHyperTransformer(TestCase):
         # Setup
         ht = HyperTransformer()
         ht._transformers_sequence = [BooleanTransformer(), NumericalTransformer()]
+        ht._fitted_fields = {'field1', 'field2'}
         ht._fitted = True
 
         # Run
@@ -88,6 +90,7 @@ class TestHyperTransformer(TestCase):
         # Assert
         assert ht._fitted is False
         assert ht._transformers_sequence == []
+        assert ht._fitted_fields == set()
 
     def test__create_multi_column_fields(self):
         """Test the ``_create_multi_column_fields`` method.
@@ -1159,7 +1162,7 @@ class TestHyperTransformer(TestCase):
         """
         # Setup
         ht = HyperTransformer()
-        ht._transformers_tree = {
+        ht._transformers_tree = defaultdict(dict, {
             'field1': {
                 'transformer': CategoricalTransformer(),
                 'outputs': ['field1.out1', 'field1.out2']
@@ -1173,7 +1176,7 @@ class TestHyperTransformer(TestCase):
                 'outputs': ['field1.out2.value']
             },
             'field2': {'transformer': CategoricalTransformer(), 'outputs': ['field2.value']}
-        }
+        })
         ht._fitted = True
 
         # Run


### PR DESCRIPTION
resolves #389, #401, #390

This PR fixes two bugs:
1. The `_unfit` method was not resetting the `_fitted_fields` attribute, so upon refitting, all of those fields were skipped and no transformers were added.
2. The `get_transformer_tree_yaml` method could not convert a `defaultdict` to be printed