### PR TITLE
Transformers that cannot work with missing values should automatically fill them in

### DIFF
--- a/rdt/performance/performance.py
+++ b/rdt/performance/performance.py
@@ -34,11 +34,9 @@ TRANSFORMER_ARGS = {
         'model_missing_values': True
     },
     'GaussianNormalizer': {
-        'missing_value_replacement': 'mean',
         'model_missing_values': True
     },
     'ClusterBasedNormalizer': {
-        'missing_value_replacement': 'mean',
         'model_missing_values': True
     },
     'PIIAnonymizer': {

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -193,11 +193,6 @@ class GaussianNormalizer(FloatFormatter):
     to :math:`u` and then to :math:`x`.
 
     Args:
-        missing_value_replacement (object or None):
-            Indicate what to do with the null values. If an integer or float is given,
-            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are
-            given, replace them with the corresponding aggregation. If ``None`` is given,
-            do not replace them. Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not. The column
             will be created only if there are null values. If ``True``, create the new column if
@@ -241,11 +236,10 @@ class GaussianNormalizer(FloatFormatter):
     _univariate = None
     COMPOSITION_IS_IDENTITY = False
 
-    def __init__(self, missing_value_replacement=None, model_missing_values=False,
-                 learn_rounding_scheme=False, enforce_min_max_values=False,
-                 distribution='parametric'):
+    def __init__(self, model_missing_values=False, learn_rounding_scheme=False,
+                 enforce_min_max_values=False, distribution='parametric'):
         super().__init__(
-            missing_value_replacement=missing_value_replacement,
+            missing_value_replacement='mean',
             model_missing_values=model_missing_values,
             learn_rounding_scheme=learn_rounding_scheme,
             enforce_min_max_values=enforce_min_max_values
@@ -391,11 +385,6 @@ class ClusterBasedNormalizer(FloatFormatter):
     based on the mean and std of the selected component.
 
     Args:
-        missing_value_replacement (object or None):
-            Indicate what to do with the null values. If an integer or float is given,
-            replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are
-            given, replace them with the corresponding aggregation. If ``None`` is given,
-            do not replace them. Defaults to ``None``.
         model_missing_values (bool):
             Whether to create a new column to indicate which values were null or not. The column
             will be created only if there are null values. If ``True``, create the new column if
@@ -433,11 +422,10 @@ class ClusterBasedNormalizer(FloatFormatter):
     _bgm_transformer = None
     valid_component_indicator = None
 
-    def __init__(self, missing_value_replacement=None, model_missing_values=False,
-                 learn_rounding_scheme=False, enforce_min_max_values=False, max_clusters=10,
-                 weight_threshold=0.005):
+    def __init__(self, model_missing_values=False, learn_rounding_scheme=False,
+                 enforce_min_max_values=False, max_clusters=10, weight_threshold=0.005):
         super().__init__(
-            missing_value_replacement=missing_value_replacement,
+            missing_value_replacement='mean',
             model_missing_values=model_missing_values,
             learn_rounding_scheme=learn_rounding_scheme,
             enforce_min_max_values=enforce_min_max_values

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -40,11 +40,9 @@ TRANSFORMER_ARGS = {
         'model_missing_values': True
     },
     'GaussianNormalizer': {
-        'missing_value_replacement': 'mean',
         'model_missing_values': True
     },
     'ClusterBasedNormalizer': {
-        'missing_value_replacement': 'mean',
         'model_missing_values': True
     },
 }

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -93,10 +93,7 @@ class TestGaussianNormalizer:
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        ct = GaussianNormalizer(
-            missing_value_replacement='mean',
-            model_missing_values=True
-        )
+        ct = GaussianNormalizer(model_missing_values=True)
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -114,10 +111,7 @@ class TestGaussianNormalizer:
         data = pd.DataFrame([1, 2, 1, 2, np.nan, 1], columns=['a'])
         column = 'a'
 
-        ct = GaussianNormalizer(
-            missing_value_replacement='mean',
-            model_missing_values=False
-        )
+        ct = GaussianNormalizer(model_missing_values=False)
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -147,10 +141,7 @@ class TestGaussianNormalizer:
         data = pd.DataFrame([1, 2, 1, 2, 1, np.nan], columns=['a'])
         column = 'a'
 
-        ct = GaussianNormalizer(
-            missing_value_replacement='mean',
-            model_missing_values=True
-        )
+        ct = GaussianNormalizer(model_missing_values=True)
         ct.fit(data, column)
         transformed = ct.transform(data)
 
@@ -194,10 +185,7 @@ class TestClusterBasedNormalizer:
         data[mask] = np.nan
         column = 'col'
 
-        bgmm_transformer = ClusterBasedNormalizer(
-            missing_value_replacement='mean',
-            model_missing_values=True
-        )
+        bgmm_transformer = ClusterBasedNormalizer(model_missing_values=True)
         bgmm_transformer.fit(data, column)
         transformed = bgmm_transformer.transform(data)
 
@@ -209,30 +197,6 @@ class TestClusterBasedNormalizer:
 
         reverse = bgmm_transformer.reverse_transform(transformed)
         np.testing.assert_array_almost_equal(reverse, data, decimal=1)
-        np.random.set_state(random_state)
-
-    def test_all_nulls(self):
-        random_state = np.random.get_state()
-        np.random.set_state(np.random.RandomState(10).get_state())
-        data = pd.DataFrame([np.nan, None] * 50, columns=['col'])
-        column = 'col'
-
-        bgmm_transformer = ClusterBasedNormalizer(
-            missing_value_replacement=0,
-            model_missing_values=True
-        )
-        bgmm_transformer.fit(data, column)
-        transformed = bgmm_transformer.transform(data)
-
-        expected = pd.DataFrame({
-            'col.normalized': [0.0] * 100,
-            'col.component': [0.0] * 100,
-            'col.is_null': [1.0] * 100
-        })
-        pd.testing.assert_frame_equal(expected, transformed)
-
-        reverse = bgmm_transformer.reverse_transform(transformed)
-        np.testing.assert_array_almost_equal(reverse, data)
         np.random.set_state(random_state)
 
     def test_data_different_sizes(self):


### PR DESCRIPTION
resolves #442 