### PR TITLE
Fix using None as transformer when update_transformers_by_sdtype

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -329,7 +329,7 @@ class HyperTransformer:
         if not isinstance(transformer, BaseTransformer) and transformer is not None:
             raise Error('Invalid transformer. Please input an rdt transformer object.')
 
-        if transformer.get_input_sdtype() != sdtype:
+        if transformer is not None and transformer.get_input_sdtype() != sdtype:
             raise Error("The transformer you've assigned is incompatible with the sdtype.")
 
         for field, field_sdtype in self.field_sdtypes.items():

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1819,6 +1819,40 @@ class TestHyperTransformer(TestCase):
         }
         assert ht.field_transformers == expected_field_transformers
 
+    def test_update_transformers_by_sdtype_with_transformer_as_none(self):
+        """Test ``update_transformers_by_sdtype`` with ``transformer`` as ``None``.
+
+        Ensure that ``update_transformers_by_sdtype`` works with ``transformer`` as ``None``.
+
+        Setup:
+            - HyperTransformer instance with ``field_transformers`` and ``field-data_types``.
+
+        Side Effects:
+            - HyperTransformer's ``field_transformers`` are upated with the ``None`` value.
+        """
+        # Setup
+        ht = HyperTransformer()
+        ff = FloatFormatter()
+        ht.field_transformers = {
+            'categorical_column': FrequencyEncoder(),
+            'numerical_column': ff,
+        }
+        ht.field_sdtypes = {
+            'categorical_column': 'categorical',
+            'numerical_column': 'numerical',
+
+        }
+
+        # Run
+        ht.update_transformers_by_sdtype('categorical', None)
+
+        # Assert
+        expected_field_transformers = {
+            'categorical_column': None,
+            'numerical_column': ff,
+        }
+        assert ht.field_transformers == expected_field_transformers
+
     @patch('rdt.hyper_transformer.warnings')
     def test_update_transformers_by_sdtype_field_sdtypes_fitted(self, mock_warnings):
         """Test ``update_transformers_by_sdtype`` if ``HyperTransformer`` has aleady been fit.


### PR DESCRIPTION
Allowing the usage of `None` transformer when updating by `sdtype`.
```python
ht = HyperTransformer()
ht.detect_initial_config(data)
ht.update_transformers_by_sdtype(sdtype='boolean', transformer=None)
```