### PR TITLE
Remove target rows containing nans for quality tests

### DIFF
--- a/tests/quality/test_quality.py
+++ b/tests/quality/test_quality.py
@@ -89,12 +89,15 @@ def get_transformer_regression_scores(data, sdtype, dataset_name, transformers, 
         numerical_transformer = FloatFormatter(model_missing_values=False)
         target = numerical_transformer.fit_transform(target, column)
         target = format_array(target)
+        nans = np.isnan(target)[:, 0]
+        target = target[~nans]
         for transformer in transformers:
             ht = HyperTransformer()
             ht.detect_initial_config(features)
             ht.update_transformers_by_sdtype(sdtype=sdtype, transformer=transformer())
             ht.fit(features)
             transformed_features = ht.transform(features).to_numpy()
+            transformed_features = transformed_features[~nans]
             score = get_regression_score(transformed_features, target)
             row = pd.Series({
                 'transformer_name': transformer.__name__,


### PR DESCRIPTION
Resolve #513 by removing all rows containing nans from the target/transformed_features. 

Note: previously `get_regression_score` simply returns `nan` as the score for all tests where the target contained nan's, but after the `scikit-learn` update it will crash instead.