### PR TITLE
Add CustomLabelEncoder transformer

### DIFF
--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -11,7 +11,8 @@ from pathlib import Path
 
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BinaryEncoder
-from rdt.transformers.categorical import FrequencyEncoder, LabelEncoder, OneHotEncoder
+from rdt.transformers.categorical import (
+    CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder)
 from rdt.transformers.datetime import OptimizedTimestampEncoder, UnixTimestampEncoder
 from rdt.transformers.null import NullTransformer
 from rdt.transformers.numerical import ClusterBasedNormalizer, FloatFormatter, GaussianNormalizer
@@ -21,6 +22,7 @@ __all__ = [
     'BaseTransformer',
     'BinaryEncoder',
     'ClusterBasedNormalizer',
+    'CustomLabelEncoder',
     'FloatFormatter',
     'FrequencyEncoder',
     'GaussianNormalizer',

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -468,8 +468,8 @@ class LabelEncoder(BaseTransformer):
         """Fit the transformer to the data.
 
         Generate a unique integer representation for each category and
-        store them in the `categories_to_values` dict and its reverse
-        `values_to_categories`.
+        store them in the ``categories_to_values`` dict and its reverse
+        ``values_to_categories``.
 
         Args:
             data (pandas.Series):
@@ -540,7 +540,7 @@ class LabelEncoder(BaseTransformer):
 class CustomLabelEncoder(LabelEncoder):
     """Custom label encoder for categorical data.
 
-    This class works very similarly to the ``LabelEncoder``, except that is requires the ordering
+    This class works very similarly to the ``LabelEncoder``, except that it requires the ordering
     for the labels to be provided.
 
     Null values are considered just another category.
@@ -555,20 +555,21 @@ class CustomLabelEncoder(LabelEncoder):
     """
 
     def __init__(self, order, add_noise=False):
-        self.order = order
+        self.order = pd.Series(order).fillna(np.nan)
         super().__init__(add_noise=add_noise)
 
     def _fit(self, data):
         """Fit the transformer to the data.
 
         Generate a unique integer representation for each category and
-        store them in the `categories_to_values` dict and its reverse
-        `values_to_categories`.
+        store them in the ``categories_to_values`` dict and its reverse
+        ``values_to_categories``.
 
         Args:
             data (pandas.Series):
                 Data to fit the transformer to.
         """
+        data = data.fillna(np.nan)
         missing = list(data[~data.isin(self.order)].unique())
         if len(missing) > 0:
             raise Error(

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -78,7 +78,8 @@ def _validate_helper(validator_function, args, steps):
 
 def _is_valid_transformer(transformer_name):
     """Determine if transformer should be tested or not."""
-    return transformer_name != 'IdentityTransformer' and 'Dummy' not in transformer_name
+    invalid_names = ['IdentityTransformer', 'Dummy', 'CustomLabelEncoder']
+    return all(invalid_name not in transformer_name for invalid_name in invalid_names)
 
 
 def _get_all_transformers():

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pandas as pd
 
-from rdt.transformers import FrequencyEncoder, LabelEncoder, OneHotEncoder
+from rdt.transformers import CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder
 
 
 def test_frequency_encoder_numerical_nans():
@@ -346,5 +346,28 @@ def test_label_encoder_order_by_alphabetical():
     reverse = transformer.reverse_transform(transformed)
 
     expected = pd.DataFrame([1, 3, 4, 2, 0], columns=['column_name.value'])
+    pd.testing.assert_frame_equal(transformed, expected)
+    pd.testing.assert_frame_equal(reverse, data)
+
+
+def test_custom_label_encoder():
+    """The the CustomLabelEncoder.
+
+    Input:
+        - pandas.DataFrame of different types of data.
+
+    Output:
+        - Transformed data should have values based on the provided order.
+        - Reverse transformed data should match the input
+    """
+
+    data = pd.DataFrame(['two', 3, 1, np.nan, 'zero'], columns=['column_name'])
+    transformer = CustomLabelEncoder(order=['zero', 1, 'two', 3, np.nan])
+    transformer.fit(data, 'column_name')
+
+    transformed = transformer.transform(data)
+    reverse = transformer.reverse_transform(transformed)
+
+    expected = pd.DataFrame([2, 3, 1, 4, 0], columns=['column_name.value'])
     pd.testing.assert_frame_equal(transformed, expected)
     pd.testing.assert_frame_equal(reverse, data)

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -351,7 +351,7 @@ def test_label_encoder_order_by_alphabetical():
 
 
 def test_custom_label_encoder():
-    """The the CustomLabelEncoder.
+    """Test the CustomLabelEncoder end to end.
 
     Input:
         - pandas.DataFrame of different types of data.
@@ -369,5 +369,28 @@ def test_custom_label_encoder():
     reverse = transformer.reverse_transform(transformed)
 
     expected = pd.DataFrame([2, 3, 1, 4, 0], columns=['column_name.value'])
+    pd.testing.assert_frame_equal(transformed, expected)
+    pd.testing.assert_frame_equal(reverse, data)
+
+
+def test_custom_label_encoder_nans():
+    """The the CustomLabelEncoder with missing values.
+
+    Input:
+        - pandas.DataFrame of different types of data and different types of missing values.
+
+    Output:
+        - Transformed data should have values based on the provided order.
+        - Reverse transformed data should match the input
+    """
+
+    data = pd.DataFrame(['two', 3, 1, np.nan, 'zero', None], columns=['column_name'])
+    transformer = CustomLabelEncoder(order=['zero', 1, 'two', 3, None])
+    transformer.fit(data, 'column_name')
+
+    transformed = transformer.transform(data)
+    reverse = transformer.reverse_transform(transformed)
+
+    expected = pd.DataFrame([2, 3, 1, 4, 0, 4], columns=['column_name.value'])
     pd.testing.assert_frame_equal(transformed, expected)
     pd.testing.assert_frame_equal(reverse, data)

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -8,9 +8,10 @@ from rdt.performance.datasets import get_dataset_generators_by_type
 from rdt.performance.performance import evaluate_transformer_performance
 from rdt.performance.profiling import profile_transformer
 from rdt.transformers import get_transformers_by_type
+from rdt.transformers.categorical import CustomLabelEncoder
 from rdt.transformers.numerical import ClusterBasedNormalizer
 
-SANDBOX_TRANSFORMERS = [ClusterBasedNormalizer]
+SANDBOX_TRANSFORMERS = [ClusterBasedNormalizer, CustomLabelEncoder]
 
 
 def _get_performance_test_cases():

--- a/tests/quality/test_quality.py
+++ b/tests/quality/test_quality.py
@@ -7,7 +7,7 @@ from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import cross_val_score
 
 from rdt import HyperTransformer
-from rdt.transformers import FloatFormatter, get_transformers_by_type
+from rdt.transformers import CustomLabelEncoder, FloatFormatter, get_transformers_by_type
 from tests.quality.utils import download_single_table
 
 R2_THRESHOLD = 0.2
@@ -23,6 +23,7 @@ TYPE_TO_DTYPE = {
     'datetime': ['datetime'],
     'boolean': ['bool']
 }
+TRANSFORMERS_TO_SKIP = [CustomLabelEncoder]
 
 
 def format_array(array):
@@ -226,6 +227,9 @@ def test_quality(subtests):
         threshold, or the comparitive score is higher than the threshold.
     """
     transformers_by_type = get_transformers_by_type()
+    transformers_by_type = {
+        k: v for k, v in transformers_by_type.items() if v not in TRANSFORMERS_TO_SKIP
+    }
     sdtypes_to_test = {
         sdtype
         for sdtype in transformers_by_type.keys()

--- a/tests/quality/test_quality.py
+++ b/tests/quality/test_quality.py
@@ -227,9 +227,11 @@ def test_quality(subtests):
         threshold, or the comparitive score is higher than the threshold.
     """
     transformers_by_type = get_transformers_by_type()
-    transformers_by_type = {
-        k: v for k, v in transformers_by_type.items() if v not in TRANSFORMERS_TO_SKIP
-    }
+    for transformer_list in transformers_by_type.values():
+        for transformer in transformer_list:
+            if transformer in TRANSFORMERS_TO_SKIP:
+                transformer_list.remove(transformer)
+
     sdtypes_to_test = {
         sdtype
         for sdtype in transformers_by_type.keys()

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -1862,13 +1862,16 @@ class TestLabelEncoder:
 class TestCustomLabelEncoder:
 
     def test___init__(self):
-        """Passed arguments must be stored as attributes."""
+        """The the ``__init__`` method.
+
+        Passed arguments must be stored as attributes.
+        """
         # Run
-        transformer = CustomLabelEncoder(order=['b', 'c', 'a'], add_noise='add_noise_value')
+        transformer = CustomLabelEncoder(order=['b', 'c', 'a', None], add_noise='add_noise_value')
 
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
-        assert transformer.order == ['b', 'c', 'a']
+        pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
 
     def test__fit(self):
         """Test the ``_fit`` method.
@@ -1895,8 +1898,13 @@ class TestCustomLabelEncoder:
         transformer._fit(data)
 
         # Assert
-        assert transformer.values_to_categories == {0: 2, 1: 3, 2: np.nan, 3: 1}
-        assert transformer.categories_to_values == {2: 0, 3: 1, 1: 3, np.nan: 2}
+        expected_values_to_categories = {0: 2, 1: 3, 2: np.nan, 3: 1}
+        expected_categories_to_values = {2: 0, 3: 1, 1: 3, np.nan: 2}
+        for key, value in transformer.values_to_categories.items():
+            assert value == expected_values_to_categories[key] or pd.isna(value)
+
+        for key, value in transformer.categories_to_values.items():
+            assert value == expected_categories_to_values.get(key) or pd.isna(key)
 
     def test__fit_error(self):
         """Test the ``_fit`` method checks that data is in ``self.order``.


### PR DESCRIPTION
resolves #507 

This PR:

- Adds a new `CustomLabelEncoder` class
- Overwrites the class' `fit` method
- Adds unit tests
- Adds integration test
- Skips performance tests, integration tests and quality tests for this transformer since the `order` param cannot be automated for now