### PR TITLE
Fix calling `null_transformer` with `model_missing_values`.

### DIFF
--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -106,7 +106,7 @@ class UnixTimestampEncoder(BaseTransformer):
         if not isinstance(data, np.ndarray):
             data = data.to_numpy()
 
-        if self.missing_value_replacement is not None:
+        if self.model_missing_values or self.missing_value_replacement is not None:
             data = self.null_transformer.reverse_transform(data)
 
         data = np.round(data.astype(np.float64))

--- a/tests/unit/transformers/test_datetime.py
+++ b/tests/unit/transformers/test_datetime.py
@@ -293,6 +293,36 @@ class TestUnixTimestampEncoder:
         datetimes = transformer.null_transformer.reverse_transform.mock_calls[0][1][0]
         np.testing.assert_array_equal(data.to_numpy(), datetimes)
 
+    def test__reverse_transform_helper_model_missing_values_true(self):
+        """Test the ``_reverse_transform_helper`` with null values.
+
+        Setup:
+            - Mock the ``instance.null_transformer``.
+            - Set the ``model_missing_values``.
+
+        Input:
+            - a pandas series.
+
+        Output:
+            - a pandas datetime index.
+
+        Expected behavior:
+            - The mock should call its ``reverse_transform`` method.
+        """
+        # Setup
+        data = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
+        transformer = UnixTimestampEncoder(model_missing_values=True)
+        transformer.null_transformer = Mock()
+        transformer.null_transformer.reverse_transform.return_value = pd.Series([1, 2, 3])
+
+        # Run
+        transformer._reverse_transform_helper(data)
+
+        # Assert
+        transformer.null_transformer.reverse_transform.assert_called_once()
+        datetimes = transformer.null_transformer.reverse_transform.mock_calls[0][1][0]
+        np.testing.assert_array_equal(data.to_numpy(), datetimes)
+
     @patch('rdt.transformers.datetime.NullTransformer')
     def test__fit(self, null_transformer_mock):
         """Test the ``_fit`` method for numpy arrays.


### PR DESCRIPTION
Fix calling the `NullTransformer` when `model_missing_values` is set to `True` on the `UnixTimestampEncoder` and other `datetime` related transformers.