### PR TITLE
Add error to `NullTransformer` when data only contains nans

### DIFF
--- a/rdt/errors.py
+++ b/rdt/errors.py
@@ -10,4 +10,4 @@ class Error(Exception):
 
 
 class TransformerInputError(Exception):
-    """Error to raise when ``HyperTransformer`` receives incorrect input."""
+    """Error to raise when ``HyperTransformer`` receives an incorrect input."""

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -5,6 +5,8 @@ import logging
 import numpy as np
 import pandas as pd
 
+from rdt.errors import TransformerInputError
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -52,9 +54,20 @@ class NullTransformer():
         Return:
             object:
                 The fill value that needs to be used.
+
+        Raise:
+            TransformerInputError:
+                Error raised when data only contains nans and ``_missing_value_replacement``
+                is set to 'mean' or  'mode'.
         """
         if self._missing_value_replacement is None:
             return None
+
+        if self._missing_value_replacement in {'mean', 'mode'} and pd.isna(data).all():
+            raise TransformerInputError(
+                f"'missing_value_replacement' cannot be set to '{self._missing_value_replacement}'"
+                ' when the provided data only contains NaNs.'
+            )
 
         if self._missing_value_replacement == 'mean':
             return data.mean()


### PR DESCRIPTION
If data only has nans and `missing_value_replacement` is mean or mode, raise an error.

The previous behavior would return np.nan when it was set to mean, and return a KeyError when set to mode.

This change makes so transformers that don't support nans (e.g. ClusterBasedNormalizer) crash with a readable error, especially since `missing_value_replacement` is set to `mean` by default.