### PR TITLE
Make `NullTransformer` deterministic

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -348,7 +348,6 @@ class BaseTransformer:
             return data
 
         data = data.copy()
-
         columns_data = self._get_columns_data(data, self.output_columns)
         reversed_data = self._reverse_transform(columns_data)
         data = data.drop(self.output_columns, axis=1)

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -136,6 +136,9 @@ class NullTransformer():
         Returns:
             pandas.Series
         """
+        if not (self._model_missing_values or self._missing_value_replacement):
+            return data
+
         data = data.copy()
         if self._model_missing_values:
             if self.nulls:

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -186,8 +186,7 @@ class FloatFormatter(BaseTransformer):
         if not isinstance(data, np.ndarray):
             data = data.to_numpy()
 
-        if self.missing_value_replacement is not None:
-            data = self.null_transformer.reverse_transform(data)
+        data = self.null_transformer.reverse_transform(data)
 
         if self.enforce_min_max_values:
             data = data.clip(self._min_value, self._max_value)

--- a/tests/unit/transformers/test_null.py
+++ b/tests/unit/transformers/test_null.py
@@ -1,7 +1,6 @@
 """Unit tests for the NullTransformer."""
 
 import re
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -514,40 +513,6 @@ class TestNullTransformer:
 
         # Assert
         expected_output = pd.Series([0.0, 0.2, 0.4, 0.6, 0.8])
-        pd.testing.assert_series_equal(expected_output, output)
-
-    @patch('rdt.transformers.null.np.random')
-    def test_reverse_transform__model_missing_values_false_nulls_true(self, random_mock):
-        """Test reverse_transform when _model_missing_values is False and nulls.
-
-        When _model_missing_values is False and the nulls attribute, a ``_null_percentage``
-        of values should randomly be replaced with ``np.nan``.
-
-        Setup:
-            - NullTransformer instance with _model_missing_values set to False and nulls
-              attribute set to True.
-            - A mock for ``np.random``.
-
-        Input:
-            - 1d numpy array with variate float values.
-
-        Expected Output:
-            - pd.Series containing the same data as input, with the random values
-            replaced with ``np.nan``.
-        """
-        # Setup
-        transformer = NullTransformer()
-        transformer._model_missing_values = False
-        transformer.nulls = True
-        transformer._null_percentage = 0.5
-        input_data = np.array([0.0, 0.2, 0.4, 0.6])
-        random_mock.random.return_value = np.array([1, 1, 0, 1])
-
-        # Run
-        output = transformer.reverse_transform(input_data)
-
-        # Assert
-        expected_output = pd.Series([0.0, 0.2, np.nan, 0.6])
         pd.testing.assert_series_equal(expected_output, output)
 
     def test_reverse_transform__model_missing_values_false_nulls_false(self):

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -518,9 +518,10 @@ class TestFloatFormatter(TestCase):
         data = np.random.random(10)
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer.learn_rounding_scheme = False
         transformer._rounding_digits = None
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -541,9 +542,10 @@ class TestFloatFormatter(TestCase):
         data = np.array([0., 1.2, 3.45, 6.789])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer._rounding_digits = None
         transformer._dtype = np.int64
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -635,9 +637,10 @@ class TestFloatFormatter(TestCase):
         data = np.array([1.1111, 2.2222, 3.3333, 4.44444, 5.555555])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer.learn_rounding_scheme = True
         transformer._rounding_digits = 2
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -661,10 +664,11 @@ class TestFloatFormatter(TestCase):
         data = np.array([2000.0, 120.0, 3100.0, 40100.0])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer._dtype = int
         transformer.learn_rounding_scheme = True
         transformer._rounding_digits = -3
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -689,9 +693,10 @@ class TestFloatFormatter(TestCase):
         data = np.array([2000.0, 120.0, 3100.0, 40100.0])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer.learn_rounding_scheme = True
         transformer._rounding_digits = -3
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -715,9 +720,10 @@ class TestFloatFormatter(TestCase):
         data = np.array([2000.554, 120.2, 3101, 4010])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer.learn_rounding_scheme = True
         transformer._rounding_digits = 0
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Assert
@@ -739,10 +745,11 @@ class TestFloatFormatter(TestCase):
         data = np.array([-np.inf, -5000, -301, -250, 0, 125, 401, np.inf])
 
         # Run
-        transformer = FloatFormatter(missing_value_replacement=None)
+        transformer = FloatFormatter()
         transformer.enforce_min_max_values = True
         transformer._max_value = 400
         transformer._min_value = -300
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Asserts
@@ -802,6 +809,7 @@ class TestFloatFormatter(TestCase):
 
         # Run
         transformer = FloatFormatter(computer_representation='Int8')
+        transformer.null_transformer = NullTransformer()
         result = transformer._reverse_transform(data)
 
         # Asserts


### PR DESCRIPTION
When neither `self._model_missing_values` nor `self._missing_value_replacement` are passed, the `NullTransformer` should not reverse_transform, and simply return the passed data.