### PR TITLE
Remove support for classes and strings in `field_transformers`. Only actual instances allowed.

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -555,6 +555,8 @@ class HyperTransformer:
             transformer.fit(data, field)
             self._transformers_sequence.append(transformer)
             data = transformer.transform(data)
+            if field in self._input_columns:
+                self.field_transformers[field] = transformer
 
             output_columns = transformer.get_output_columns()
             next_transformers = transformer.get_next_transformers()

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -358,6 +358,8 @@ class HyperTransformer:
     def update_sdtypes(self, column_name_to_sdtype):
         """Update the ``sdtypes`` for each specified column name.
 
+        The method may also update ``field_transformers`` to match the new sdtypes.
+
         Args:
             column_name_to_sdtype(dict):
                 Dict mapping column names to ``sdtypes`` for that column.
@@ -367,7 +369,6 @@ class HyperTransformer:
 
         update_columns = column_name_to_sdtype.keys()
         self._validate_update_columns(update_columns)
-
         self._validate_sdtypes(column_name_to_sdtype)
 
         transformers_to_update = {}
@@ -379,7 +380,7 @@ class HyperTransformer:
                     supported_sdtypes = current_transformer.get_supported_sdtypes()
 
                 if sdtype not in supported_sdtypes:
-                    transformers_to_update[column] = get_default_transformer(sdtype)
+                    transformers_to_update[column] = deepcopy(get_default_transformer(sdtype))
 
         self.field_sdtypes.update(column_name_to_sdtype)
         self.field_transformers.update(transformers_to_update)

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -1,9 +1,9 @@
 """Hyper transformer module."""
 
-from copy import deepcopy
 import inspect
 import json
 import warnings
+from copy import deepcopy
 
 import pandas as pd
 
@@ -495,7 +495,8 @@ class HyperTransformer:
             if field not in self.field_transformers:
                 sdtype = self.field_sdtypes[field]
                 if sdtype in self._default_sdtype_transformers:
-                    self.field_transformers[field] = deepcopy(self._default_sdtype_transformers[sdtype])
+                    self.field_transformers[field] = deepcopy(
+                        self._default_sdtype_transformers[sdtype])
                 else:
                     self.field_transformers[field] = deepcopy(get_default_transformer(sdtype))
 
@@ -552,7 +553,6 @@ class HyperTransformer:
             self._output_columns.append(field)
 
         else:
-            #transformer = get_transformer_instance(transformer)
             transformer.fit(data, field)
             self._transformers_sequence.append(transformer)
             data = transformer.transform(data)

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -351,7 +351,7 @@ class HyperTransformer:
 
         for field, field_sdtype in self.field_sdtypes.items():
             if field_sdtype == sdtype:
-                self.field_transformers[field] = transformer_instance
+                self.field_transformers[field] = deepcopy(transformer_instance)
 
         self._modified_config = True
 

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -1,5 +1,6 @@
 """Hyper transformer module."""
 
+from copy import deepcopy
 import inspect
 import json
 import warnings
@@ -494,9 +495,9 @@ class HyperTransformer:
             if field not in self.field_transformers:
                 sdtype = self.field_sdtypes[field]
                 if sdtype in self._default_sdtype_transformers:
-                    self.field_transformers[field] = self._default_sdtype_transformers[sdtype]
+                    self.field_transformers[field] = deepcopy(self._default_sdtype_transformers[sdtype])
                 else:
-                    self.field_transformers[field] = get_default_transformer(sdtype)
+                    self.field_transformers[field] = deepcopy(get_default_transformer(sdtype))
 
     def detect_initial_config(self, data):
         """Print the configuration of the data.
@@ -551,12 +552,10 @@ class HyperTransformer:
             self._output_columns.append(field)
 
         else:
-            transformer = get_transformer_instance(transformer)
+            #transformer = get_transformer_instance(transformer)
             transformer.fit(data, field)
             self._transformers_sequence.append(transformer)
             data = transformer.transform(data)
-            if field in self._input_columns:
-                self.field_transformers[field] = transformer
 
             output_columns = transformer.get_output_columns()
             next_transformers = transformer.get_next_transformers()

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -10,7 +10,7 @@ import pandas as pd
 from rdt.errors import Error, NotFittedError, TransformerInputError
 from rdt.transformers import (
     BaseTransformer, get_class_by_transformer_name, get_default_transformer,
-    get_transformer_instance, get_transformers_by_type)
+    get_transformers_by_type)
 
 
 class Config(dict):
@@ -172,11 +172,8 @@ class HyperTransformer:
         """
         invalid_transformers_columns = []
         for column_name, transformer in column_name_to_transformer.items():
-            if transformer is not None:
-                try:
-                    get_transformer_instance(transformer)
-                except (ValueError, AttributeError):
-                    invalid_transformers_columns.append(column_name)
+            if transformer and not isinstance(transformer, BaseTransformer):
+                invalid_transformers_columns.append(column_name)
 
         if invalid_transformers_columns:
             raise Error(
@@ -399,7 +396,7 @@ class HyperTransformer:
 
         Args:
             column_name_to_transformer(dict):
-                Dict mapping column names to transformers to be used for that column.
+                Dict mapping column names to transformer instances.
         """
         if self._fitted:
             warnings.warn(self._REFIT_MESSAGE)

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
     'PseudoAnonymizedFaker',
     'get_transformer_name',
     'get_transformer_class',
-    'get_transformer_instance',
     'get_transformers_by_type',
     'get_default_transformers',
     'get_default_transformer',
@@ -125,29 +124,6 @@ def get_transformer_class(transformer):
 
     package, name = transformer.rsplit('.', 1)
     return getattr(importlib.import_module(package), name)
-
-
-def get_transformer_instance(transformer):
-    """Load a new instance of a ``Transformer``.
-
-    The ``transformer`` is expected to be the transformers path as a ``string``,
-    a transformer instance or a transformer type.
-
-    Args:
-        transformer (str or BaseTransformer):
-            String with the transformer path or instance of a BaseTransformer subclass.
-
-    Returns:
-        BaseTransformer:
-            BaseTransformer subclass instance.
-    """
-    if isinstance(transformer, BaseTransformer):
-        return deepcopy(transformer)
-
-    if inspect.isclass(transformer) and issubclass(transformer, BaseTransformer):
-        return transformer()
-
-    return get_transformer_class(transformer)()
 
 
 @lru_cache()

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -251,10 +251,8 @@ class BaseTransformer:
                 Column name. Must be present in the data.
         """
         self._store_columns(column, data)
-
         columns_data = self._get_columns_data(data, self.columns)
         self._fit(columns_data)
-
         self._build_output_columns(data)
 
     def _transform(self, columns_data):

--- a/tests/contributing.py
+++ b/tests/contributing.py
@@ -40,13 +40,6 @@ CHECK_DETAILS = {
             'original sdtype.'
         ),
     ),
-    '_validate_composition': (
-        'Composition is Identity',
-        (
-            'Transforming data and reversing it recovers the original data, if composition is '
-            'identity is specified.'
-        ),
-    ),
     '_validate_hypertransformer_transformed_data': (
         'Hypertransformer can transform',
         'The HyperTransformer is able to use the Transformer and produce float values.',

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -431,7 +431,7 @@ def test_multiple_detect_configs_with_set_config():
 
     ht.set_config(config={
         'sdtypes': {'integers': 'categorical'},
-        'transformers': {'integers': FrequencyEncoder}
+        'transformers': {'integers': FrequencyEncoder()}
     })
 
     ht.detect_initial_config(data)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -139,8 +139,10 @@ def test_hypertransformer_default_inputs():
     # Run
     ht = HyperTransformer()
     ht.detect_initial_config(data)
+    print(ht.get_config())
     ht.fit(data)
     transformed = ht.transform(data)
+    print(transformed)
     reverse_transformed = ht.reverse_transform(transformed)
 
     # Assert

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -139,10 +139,8 @@ def test_hypertransformer_default_inputs():
     # Run
     ht = HyperTransformer()
     ht.detect_initial_config(data)
-    print(ht.get_config())
     ht.fit(data)
     transformed = ht.transform(data)
-    print(transformed)
     reverse_transformed = ht.reverse_transform(transformed)
 
     # Assert
@@ -240,10 +238,10 @@ def test_hypertransformer_field_transformers():
         'transformers': {
             'integer': FloatFormatter(missing_value_replacement='mean'),
             'float': FloatFormatter(missing_value_replacement='mean'),
-            'categorical': FrequencyEncoder,
+            'categorical': FrequencyEncoder(),
             'bool': BinaryEncoder(missing_value_replacement='mode'),
-            'datetime': DummyTransformerNotMLReady,
-            'names': FrequencyEncoder
+            'datetime': DummyTransformerNotMLReady(),
+            'names': FrequencyEncoder()
         }
     }
 
@@ -401,7 +399,7 @@ def test_multiple_fits_with_set_config():
     ht.detect_initial_config(data)
     ht.set_config(config={
         'sdtypes': {'integer': 'categorical'},
-        'transformers': {'integer': FrequencyEncoder}
+        'transformers': {'integer': FrequencyEncoder()}
     })
     ht.fit(data)
     transformed1 = ht.transform(data)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -936,3 +936,49 @@ def test_hyper_transformer_chained_transformers_various_transformers():
 
     reverse_transformed = ht.reverse_transform(transformed)
     pd.testing.assert_frame_equal(reverse_transformed, data)
+
+
+def test_hyper_transformer_field_transformer_correctly_set():
+    """Test field_transformers is correctly set through various methods."""
+    # Setup
+    ht = HyperTransformer()
+    data = pd.DataFrame({'col': ['a', 'b', 'c']})
+
+    # getting detected transformers should give the actual transformer
+    ht.detect_initial_config(data)
+    transformer = ht.get_config()['transformers']['col']
+    transformer.new_attribute = 'abc'
+    assert ht.get_config()['transformers']['col'].new_attribute == 'abc'
+
+    # the actual transformer should be fitted
+    ht.fit(data)
+    transformer.new_attribute2 = '123'
+    assert ht.get_config()['transformers']['col'].new_attribute == 'abc'
+    assert ht.get_config()['transformers']['col'].new_attribute2 == '123'
+
+    # if a transformer was set, it should use the provided instance
+    fe = FrequencyEncoder()
+    ht.set_config({'sdtypes': {'col': 'categorical'}, 'transformers': {'col': fe}})
+    ht.fit(data)
+    transformer = ht.get_config()['transformers']['col']
+    assert transformer is fe
+
+    # the three cases below make sure any form of acess to the field_transformers
+    # correctly accesses and stores the actual transformers
+    fe = FrequencyEncoder()
+    ht.update_transformers({'col': fe})
+    ht.fit(data)
+    transformer = ht.get_config()['transformers']['col']
+    assert transformer is fe
+
+    ht.update_transformers_by_sdtype('categorical', transformer_name='FrequencyEncoder')
+    transformer = ht.get_config()['transformers']['col']
+    transformer.new_attribute3 = 'abc'
+    ht.fit(data)
+    assert ht.get_config()['transformers']['col'].new_attribute3 == 'abc'
+
+    ht.update_sdtypes({'col': 'text'})
+    transformer = ht.get_config()['transformers']['col']
+    transformer.new_attribute3 = 'abc'
+    ht.fit(data)
+    assert ht.get_config()['transformers']['col'].new_attribute3 == 'abc'

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -207,7 +207,7 @@ def _test_transformer_with_hypertransformer(transformer_class, input_data, steps
 
     else:
         field_transformers = {
-            TEST_COL: transformer_class
+            TEST_COL: transformer_class()
         }
 
     sdtypes = {}

--- a/tests/quality/test_quality.py
+++ b/tests/quality/test_quality.py
@@ -70,7 +70,7 @@ def get_transformer_regression_scores(data, sdtype, dataset_name, transformers, 
         dataset_name (string):
             The name of the dataset.
         transformers (list):
-            List of transformer instances.
+            List of transformer classes.
         metadata (dict):
             Dictionary containing metadata for the table.
 
@@ -95,7 +95,8 @@ def get_transformer_regression_scores(data, sdtype, dataset_name, transformers, 
         for transformer in transformers:
             ht = HyperTransformer()
             ht.detect_initial_config(features)
-            ht.update_transformers_by_sdtype(sdtype=sdtype, transformer=transformer())
+            ht.update_transformers_by_sdtype(
+                sdtype=sdtype, transformer_name=transformer.get_name())
             ht.fit(features)
             transformed_features = ht.transform(features).to_numpy()
             transformed_features = transformed_features[~nans]

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1842,10 +1842,9 @@ class TestHyperTransformer(TestCase):
         """
         # Setup
         ht = HyperTransformer()
-        ff = FloatFormatter()
         ht.field_transformers = {
             'categorical_column': FrequencyEncoder(),
-            'numerical_column': ff,
+            'numerical_column': FloatFormatter(),
         }
         ht.field_sdtypes = {
             'categorical_column': 'categorical',
@@ -1858,11 +1857,8 @@ class TestHyperTransformer(TestCase):
         ht.update_transformers_by_sdtype('categorical', transformer)
 
         # Assert
-        expected_field_transformers = {
-            'categorical_column': transformer,
-            'numerical_column': ff,
-        }
-        assert ht.field_transformers == expected_field_transformers
+        assert isinstance(ht.field_transformers['categorical_column'], LabelEncoder)
+        assert isinstance(ht.field_transformers['numerical_column'], FloatFormatter)
 
     @patch('rdt.hyper_transformer.warnings')
     def test_update_transformers_by_sdtype_field_sdtypes_fitted(self, mock_warnings):
@@ -1905,7 +1901,7 @@ class TestHyperTransformer(TestCase):
         ]
 
         mock_warnings.warn.assert_has_calls(expected_warnings_msgs)
-        assert ht.field_transformers == {'categorical_column': transformer}
+        assert isinstance(ht.field_transformers['categorical_column'], LabelEncoder)
 
     def test_update_transformers_by_sdtype_unsupported_sdtype_raises_error(self):
         """Passing an incorrect ``sdtype`` should raise an error."""

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1132,6 +1132,20 @@ class TestHyperTransformer(TestCase):
         bool_transformer.transform.assert_called_once()
         datetime_transformer.transform.assert_called_once()
 
+    def test_fit_updates_field_transformers(self):
+        """Test it updates the  ``field_transformers`` dict."""
+        # Setup
+        ht = HyperTransformer()
+        data = pd.DataFrame({'col': [1, 2, 3]})
+
+        # Run
+        ht.set_config(
+            {'sdtypes': {'col': 'numerical'}, 'transformers': {'col': FloatFormatter()}})
+        ht.fit(data)
+
+        # Assert
+        assert ht.get_config()['transformers']['col'].get_output_columns() == ['col']
+
     def test_transform_raises_error_no_config(self):
         """Test that ``transform`` raises an error.
 

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1123,18 +1123,18 @@ class TestHyperTransformer(TestCase):
         datetime_transformer.transform.assert_called_once()
 
     def test_fit_updates_field_transformers(self):
-        """Test it updates the  ``field_transformers`` dict."""
+        """Test it updates the  ``field_transformers`` dict with the actual instance."""
         # Setup
         ht = HyperTransformer()
         data = pd.DataFrame({'col': [1, 2, 3]})
+        ff = FloatFormatter()
 
         # Run
-        ht.set_config(
-            {'sdtypes': {'col': 'numerical'}, 'transformers': {'col': FloatFormatter()}})
+        ht.set_config({'sdtypes': {'col': 'numerical'}, 'transformers': {'col': ff}})
         ht.fit(data)
 
         # Assert
-        assert ht.get_config()['transformers']['col'].get_output_columns() == ['col']
+        assert ht.get_config()['transformers']['col'] == ff
 
     def test_transform_raises_error_no_config(self):
         """Test that ``transform`` raises an error.

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -351,8 +351,7 @@ class TestHyperTransformer(TestCase):
         ))
         assert output == expected_output
 
-    @patch('rdt.hyper_transformer.get_transformer_instance')
-    def test__fit_field_transformer(self, get_transformer_instance_mock):
+    def test__fit_field_transformer(self):
         """Test the ``_fit_field_transformer`` method.
 
         This tests that the ``_fit_field_transformer`` behaves as expected.
@@ -361,8 +360,6 @@ class TestHyperTransformer(TestCase):
         itself recursively if it can.
 
         Setup:
-            - A mock for ``get_transformer_instance``.
-            - A mock for the transformer returned by ``get_transformer_instance``.
             The ``get_output_sdtypes`` method will return two outputs, one that
             is ML ready and one that isn't.
 
@@ -395,7 +392,6 @@ class TestHyperTransformer(TestCase):
             'a.out1.is_null': None
         }
         transformer2.transform.return_value = transformed_data1
-        get_transformer_instance_mock.side_effect = [transformer1, transformer2]
         ht = HyperTransformer()
 
         # Run
@@ -2913,11 +2909,7 @@ class TestHyperTransformer(TestCase):
         with pytest.raises(Error, match=error_msg):
             ht.remove_transformers_by_sdtype('phone_number')
 
-    @patch('rdt.hyper_transformer.get_transformer_instance')
-    def test__fit_field_transformer_multi_column_field_not_ready(
-        self,
-        get_transformer_instance_mock
-    ):
+    def test__fit_field_transformer_multi_column_field_not_ready(self,):
         """Test the ``_fit_field_transformer`` method.
 
         This tests that the ``_fit_field_transformer`` behaves as expected.
@@ -2926,8 +2918,6 @@ class TestHyperTransformer(TestCase):
         It should however, transform the data.
 
         Setup:
-            - A mock for ``get_transformer_instance``.
-            - A mock for the transformer returned by ``get_transformer_instance``.
             The ``get_output_sdtypes`` method will return one output that is part of
             a multi-column field.
             - A mock for ``_multi_column_fields`` to return the multi-column field.
@@ -2953,7 +2943,6 @@ class TestHyperTransformer(TestCase):
         transformer1.get_output_columns.return_value = ['a.out1']
         transformer1.get_next_transformers.return_value = {('a.out1', 'b.out1'): transformer2}
         transformer1.transform.return_value = transformed_data1
-        get_transformer_instance_mock.side_effect = [transformer1]
         ht = HyperTransformer()
         ht._multi_column_fields = Mock()
         ht._multi_column_fields.get.return_value = ('a.out1', 'b.out1')

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -2590,7 +2590,7 @@ class TestHyperTransformer(TestCase):
         instance._fitted = False
         instance._user_message = Mock()
         instance.field_sdtypes = {'a': 'categorical'}
-        transformer_mock = Mock()
+        transformer_mock = FloatFormatter()
         default_mock.return_value = transformer_mock
         column_name_to_sdtype = {
             'a': 'numerical'
@@ -2606,7 +2606,7 @@ class TestHyperTransformer(TestCase):
         )
         mock_warnings.warn.assert_not_called()
         assert instance.field_sdtypes == {'a': 'numerical'}
-        assert instance.field_transformers == {'a': transformer_mock}
+        assert isinstance(instance.field_transformers['a'], FloatFormatter)
         instance._user_message.assert_called_once_with(user_message, 'Info')
 
     @patch('rdt.hyper_transformer.warnings')

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -1,7 +1,6 @@
 import pytest
 
-from rdt.transformers import (
-    BinaryEncoder, get_transformer_class, get_transformer_instance, get_transformer_name)
+from rdt.transformers import BinaryEncoder, get_transformer_class, get_transformer_name
 from rdt.transformers.addons.identity.identity import IdentityTransformer
 
 
@@ -86,36 +85,3 @@ def test_get_transformer_class_transformer_path_addon():
 
     # Assert
     assert returned == IdentityTransformer
-
-
-def test_get_transformer_instance_instance():
-    transformer = BinaryEncoder(missing_value_replacement=None)
-
-    returned = get_transformer_instance(transformer)
-
-    assert isinstance(returned, BinaryEncoder)
-    assert returned.missing_value_replacement == 'mode'
-
-
-def test_get_transformer_instance_str():
-    transformer = 'rdt.transformers.BinaryEncoder'
-
-    returned = get_transformer_instance(transformer)
-
-    assert isinstance(returned, BinaryEncoder)
-
-
-def test_get_transformer_instance_addon():
-    transformer = 'rdt.transformers.addons.identity.identity.IdentityTransformer'
-
-    returned = get_transformer_instance(transformer)
-
-    assert isinstance(returned, IdentityTransformer)
-
-
-def test_get_transformer_instance_class():
-    transformer = BinaryEncoder
-
-    returned = get_transformer_instance(transformer)
-
-    assert isinstance(returned, BinaryEncoder)

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -66,6 +66,15 @@ def test_get_transformer_class_transformer_path():
     assert returned == BinaryEncoder
 
 
+def test_get_transformer_class_partial_path():
+    """Test with non fully specified path."""
+    # Run
+    returned = get_transformer_class('rdt.transformers.BinaryEncoder')
+
+    # Assert
+    assert returned == BinaryEncoder
+
+
 def test_get_transformer_class_transformer_path_addon():
     """Test the ``get_transformer_class`` method.
 


### PR DESCRIPTION
Resolve #541.