### PR TITLE
Fixing workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest]   # skip windows bc rundoc fails
+        os: [ubuntu-20.04, macos-latest]   # skip windows bc rundoc fails
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,6 +28,6 @@ jobs:
       run: invoke check-dependencies
     - name: Run Unit tests
       run: invoke unit
-    - if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+    - if: matrix.os == 'ubuntu-20.04' && matrix.python-version == 3.8
       name: Upload codecov report
       uses: codecov/codecov-action@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This updates the workflows to use `ubuntu-20.04` since the `ubuntu-latest` tag is on a rolling migration to version [22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) which doesn't support python 3.6. Once we remove python 3.6 support, we can change this back