### PR TITLE
Use FutureWarning instead of DeprecationWarning

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -297,14 +297,14 @@ class HyperTransformer:
                 warnings.warn(
                     "The 'transformer' parameter will no longer be supported in future versions "
                     "of the RDT. Using the 'transformer_name' parameter instead.",
-                    DeprecationWarning
+                    FutureWarning
                 )
 
         else:
             warnings.warn(
                 "The 'transformer' parameter will no longer be supported in future versions "
                 "of the RDT. Please use the 'transformer_name' and 'transformer_parameters' "
-                'parameters instead.', DeprecationWarning
+                'parameters instead.', FutureWarning
             )
 
     def update_transformers_by_sdtype(

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -31,7 +31,7 @@ class BaseTransformer:
         if missing_value_replacement is None:
             warnings.warn(
                 "Setting 'missing_value_replacement' to 'None' is no longer supported. "
-                f"Imputing with the '{default}' instead.", DeprecationWarning
+                f"Imputing with the '{default}' instead.", FutureWarning
             )
             self.missing_value_replacement = default
         else:

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -2082,7 +2082,7 @@ class TestHyperTransformer(TestCase):
             "The 'transformer' parameter will no longer be supported in future versions "
             "of the RDT. Using the 'transformer_name' parameter instead."
         )
-        mock_warning.warn.assert_called_once_with(expected_msg, DeprecationWarning)
+        mock_warning.warn.assert_called_once_with(expected_msg, FutureWarning)
         assert len(ht.field_transformers) == 2
         assert ht.field_transformers['numerical_column'] == ff
         assert isinstance(ht.field_transformers['categorical_column'], LabelEncoder)

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1894,7 +1894,7 @@ class TestHyperTransformer(TestCase):
             call(
                 "The 'transformer' parameter will no longer be supported in future "
                 "versions of the RDT. Please use the 'transformer_name' and "
-                "'transformer_parameters' parameters instead.", DeprecationWarning
+                "'transformer_parameters' parameters instead.", FutureWarning
             )
         ]
 


### PR DESCRIPTION
By default, `DeprecationWarnings` are silenced. According to [python's documentation for warnings](https://docs.python.org/3/library/warnings.html), if we want to raise a warning that users will see indicating a future change, we should use `FutureWarning` instead.

resolves #582 