### PR TITLE
Randomize nulls

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -78,8 +78,8 @@ class BaseTransformer:
         self.output_properties = {None: {'sdtype': 'float', 'next_transformer': None}}
         self.random_states = {
             'fit': self.INITIAL_FIT_STATE,
-            'transform': np.random.RandomState(42),
-            'reverse_transform': np.random.RandomState(42)
+            'transform': None,
+            'reverse_transform': None
         }
 
     def set_random_state(self, state, method_name):

--- a/rdt/transformers/pii/anonymizer.py
+++ b/rdt/transformers/pii/anonymizer.py
@@ -120,7 +120,7 @@ class AnonymizedFaker(BaseTransformer):
 
         return getattr(self.faker, self.function_name)(**self.function_kwargs)
 
-    def _set_seed(self, data):
+    def _set_faker_seed(self, data):
         hash_value = self.get_input_column()
         for value in data.head(5):
             hash_value += str(value)
@@ -136,7 +136,7 @@ class AnonymizedFaker(BaseTransformer):
             data (pandas.Series):
                 Data to fit to.
         """
-        self._set_seed(data)
+        self._set_faker_seed(data)
         self.data_length = len(data)
 
     def _transform(self, _data):
@@ -255,7 +255,7 @@ class PseudoAnonymizedFaker(AnonymizedFaker):
             data (pandas.Series):
                 Data to fit the transformer to.
         """
-        self._set_seed(columns_data)
+        self._set_faker_seed(columns_data)
         unique_values = columns_data[columns_data.notna()].unique()
         unique_data_length = len(unique_values)
         try:

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -1061,11 +1061,11 @@ def test_hyper_transformer_reset_randomization():
         ],
         'balance.component': [0.0, 0, 0, 0, 0],
         'card_type': [
-            0.3273532539594452,
-            0.36028672438848,
-            0.665212975367718,
-            0.8806283675768456,
-            0.23386325679767678
+            0.31440326318001877,
+            0.2879792449993428,
+            0.7147347796329043,
+            0.9397813187279729,
+            0.25144169889394075
         ]
     })
     expected_second_transformed = pd.DataFrame({
@@ -1080,11 +1080,11 @@ def test_hyper_transformer_reset_randomization():
         ],
         'balance.component': [0.0, 0, 0, 0, 0],
         'card_type': [
-            0.24748494176070168,
-            0.3886965582883772,
-            0.7408364277428201,
-            0.9194352110397322,
-            0.2293601452128275
+            0.20248666820805558,
+            0.4408301080724041,
+            0.7082705433167992,
+            0.8911691002937682,
+            0.2679993642397502
         ]
     })
 
@@ -1109,8 +1109,8 @@ def test_hyper_transformer_reset_randomization():
         ],
         'age': [18, 25, 54, 60, 31],
         'name': ['AAAAA', 'AAAAB', 'AAAAC', 'AAAAD', 'AAAAE'],
-        'signup_day': [np.nan, '02/19/2016', '04/01/2019', np.nan, '05/16/2016'],
-        'balance': [np.nan, 5400, 150000, np.nan, 91000],
+        'signup_day': ['01/01/2020', '02/19/2016', '04/01/2019', np.nan, np.nan],
+        'balance': [250, 5400, 150000, 61662.5, 91000],
         'card_type': ['Visa', 'Visa', 'Master Card', 'Amex', 'Visa']
     })
     expected_second_reverse = pd.DataFrame({
@@ -1123,8 +1123,8 @@ def test_hyper_transformer_reset_randomization():
         ],
         'age': [18, 25, 54, 60, 31],
         'name': ['AAAAF', 'AAAAG', 'AAAAH', 'AAAAI', 'AAAAJ'],
-        'signup_day': ['01/01/2020', '02/19/2016', np.nan, '12/01/2008', '05/16/2016'],
-        'balance': [250, 5400, np.nan, 61662.5, 91000],
+        'signup_day': ['01/01/2020', np.nan, '04/01/2019', '12/01/2008', np.nan],
+        'balance': [np.nan, 5400, np.nan, 61662.5, 91000],
         'card_type': ['Visa', 'Visa', 'Master Card', 'Amex', 'Visa']
     })
     first_reverse1 = ht1.reverse_transform(first_transformed1)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -1305,3 +1305,18 @@ def test_hypertransformer_anonymized_faker_multi_table():
     # Assert
     assert reverse_transformed1['id1'].tolist() != reverse_transformed2['id1'].tolist()
     assert reverse_transformed1['id2'].tolist() != reverse_transformed2['id2'].tolist()
+
+def test_random_seed():
+    data = pd.DataFrame(data={
+        'low':    [1, 4, np.nan, 0,      4,      np.nan, np.nan, 5,      np.nan],
+        'middle': [2, 5, 3,      np.nan, 5,      np.nan, 5,      np.nan, np.nan],
+        'high':   [3, 7, 8,      4,      np.nan, 9,      np.nan, np.nan, np.nan]
+    })
+
+    ht = HyperTransformer()
+    ht.detect_initial_config(data)
+    ht.fit(data)
+    transformed = ht.transform(data)
+    reverse_transformed = ht.reverse_transform(transformed)
+    print(reverse_transformed)
+    assert 0

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -12,6 +12,8 @@ from rdt.transformers import (
     AnonymizedFaker, BaseTransformer, BinaryEncoder, ClusterBasedNormalizer, FloatFormatter,
     FrequencyEncoder, LabelEncoder, OneHotEncoder, RegexGenerator, UnixTimestampEncoder,
     get_default_transformer, get_default_transformers)
+from rdt.transformers.datetime import OptimizedTimestampEncoder
+from rdt.transformers.numerical import GaussianNormalizer
 from rdt.transformers.pii.anonymizer import PseudoAnonymizedFaker
 
 
@@ -1306,17 +1308,53 @@ def test_hypertransformer_anonymized_faker_multi_table():
     assert reverse_transformed1['id1'].tolist() != reverse_transformed2['id1'].tolist()
     assert reverse_transformed1['id2'].tolist() != reverse_transformed2['id2'].tolist()
 
+
 def test_random_seed():
-    data = pd.DataFrame(data={
-        'low':    [1, 4, np.nan, 0,      4,      np.nan, np.nan, 5,      np.nan],
-        'middle': [2, 5, 3,      np.nan, 5,      np.nan, 5,      np.nan, np.nan],
-        'high':   [3, 7, 8,      4,      np.nan, 9,      np.nan, np.nan, np.nan]
+    # Setup
+    data = pd.DataFrame({
+        'num1': [1, np.nan, 2] * 10,
+        'num2': [1, np.nan, 2] * 10,
+        'num3': [1, np.nan, 2] * 10,
+        'num4': [1, np.nan, 2] * 10,
+        'num5': [1, np.nan, 2] * 10,
+        'num6': [1, np.nan, 2] * 10,
+        'date1': [np.datetime64('2020-10-10'), np.datetime64('2021-11-11'), np.nan] * 10,
+        'date2': [np.datetime64('2020-10-10'), np.datetime64('2021-11-11'), np.nan] * 10,
+        'date3': [np.datetime64('2020-10-10'), np.datetime64('2021-11-11'), np.nan] * 10,
+        'date4': [np.datetime64('2020-10-10'), np.datetime64('2021-11-11'), np.nan] * 10,
     })
 
     ht = HyperTransformer()
     ht.detect_initial_config(data)
+    ht.update_transformers({
+        'num1': FloatFormatter(),
+        'num2': FloatFormatter(),
+        'num3': ClusterBasedNormalizer(),
+        'num4': ClusterBasedNormalizer(),
+        'num5': GaussianNormalizer(),
+        'num6': GaussianNormalizer(),
+        'date1': UnixTimestampEncoder(),
+        'date2': UnixTimestampEncoder(),
+        'date3': OptimizedTimestampEncoder(),
+        'date4': OptimizedTimestampEncoder(),
+    })
+
+    # Run
     ht.fit(data)
     transformed = ht.transform(data)
-    reverse_transformed = ht.reverse_transform(transformed)
-    print(reverse_transformed)
-    assert 0
+    reversed1 = ht.reverse_transform(transformed)
+
+    # Assert
+    assert reversed1['num1'].isna().tolist() != reversed1['num2'].isna().tolist()
+    assert reversed1['num3'].isna().tolist() != reversed1['num4'].isna().tolist()
+    assert reversed1['num5'].isna().tolist() != reversed1['num6'].isna().tolist()
+    assert reversed1['date1'].isna().tolist() != reversed1['date2'].isna().tolist()
+    assert reversed1['date3'].isna().tolist() != reversed1['date4'].isna().tolist()
+
+    # Run
+    ht.reset_randomization()
+    transformed = ht.transform(data)
+    reversed2 = ht.reverse_transform(transformed)
+
+    # Assert
+    pd.testing.assert_frame_equal(reversed1, reversed2)

--- a/tests/integration/transformers/test_datetime.py
+++ b/tests/integration/transformers/test_datetime.py
@@ -8,10 +8,10 @@ class TestUnixTimestampEncoder:
     def test_unixtimestampencoder(self):
         ute = UnixTimestampEncoder(missing_value_replacement='mean')
         data = pd.DataFrame({'column': pd.to_datetime([None, '1996-10-17', '1965-05-23'])})
-        ute.set_random_state(np.random.RandomState(7), 'reverse_transform')
 
         # Run
         ute.fit(data, column='column')
+        ute.set_random_state(np.random.RandomState(7), 'reverse_transform')
         transformed = ute.transform(data)
         reverted = ute.reverse_transform(transformed)
 
@@ -26,10 +26,10 @@ class TestUnixTimestampEncoder:
     def test_unixtimestampencoder_different_format(self):
         ute = UnixTimestampEncoder(missing_value_replacement='mean', datetime_format='%b %d, %Y')
         data = pd.DataFrame({'column': [None, 'Oct 17, 1996', 'May 23, 1965']})
-        ute.set_random_state(np.random.RandomState(7), 'reverse_transform')
 
         # Run
         ute.fit(data, column='column')
+        ute.set_random_state(np.random.RandomState(7), 'reverse_transform')
         transformed = ute.transform(data)
         reverted = ute.reverse_transform(transformed)
 
@@ -44,11 +44,11 @@ class TestUnixTimestampEncoder:
 class TestOptimizedTimestampEncoder:
     def test_optimizedtimestampencoder(self):
         ote = OptimizedTimestampEncoder(missing_value_replacement='mean')
-        ote.set_random_state(np.random.RandomState(7), 'reverse_transform')
         data = pd.DataFrame({'column': pd.to_datetime([None, '1996-10-17', '1965-05-23'])})
 
         # Run
         ote.fit(data, column='column')
+        ote.set_random_state(np.random.RandomState(7), 'reverse_transform')
         transformed = ote.transform(data)
         reverted = ote.reverse_transform(transformed)
 

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -119,7 +119,8 @@ class TestGaussianNormalizer:
         assert transformed.shape == (6, 1)
 
         reverse = ct.reverse_transform(transformed)
-        expected = pd.DataFrame([np.nan, 2, 1, np.nan, 1.4, 1], columns=['a'])
+        expected = pd.DataFrame(
+            [1., 1.9999999510423996, 1., 1.9999999510423996, 1.4, 1.], columns=['a'])
         pd.testing.assert_frame_equal(reverse, expected)
 
     def test_int(self):

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -1360,6 +1360,7 @@ class TestHyperTransformer(TestCase):
         instance._fitted = True
         instance._modified_config = False
         instance._subset.return_value = False
+        instance.random_state = {}
 
         random_element = AnonymizedFaker(
             function_name='random_element',
@@ -1367,6 +1368,7 @@ class TestHyperTransformer(TestCase):
         )
         random_element.columns = ['random_element']
         random_element.output_columns = []
+        random_element.set_random_state(np.random.RandomState(42), 'reverse_transform')
 
         regex_id = RegexGenerator(regex_format='id_[0-9]')
         regex_id.reset_randomization()

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -118,19 +118,13 @@ class TestBaseTransformer:
         # Setup
         transformer = BaseTransformer()
         transformer.random_states['fit'] = 0
-        transformer.random_states['transform'] = 2
-        transformer.random_states['reverse_transform'] = None
 
         # Run
         transformer.reset_randomization()
 
         # Assert
         fit_state = transformer.INITIAL_FIT_STATE
-        transform_state = transformer.INITIAL_TRANSFORM_STATE
-        reverse_transform_state = transformer.INITIAL_REVERSE_TRANSFORM_STATE
         assert transformer.random_states['fit'] == fit_state
-        assert transformer.random_states['transform'] == transform_state
-        assert transformer.random_states['reverse_transform'] == reverse_transform_state
 
     def test_get_subclasses(self):
         """Test the ``get_subclasses`` method.
@@ -1004,6 +998,7 @@ class TestBaseTransformer:
         dummy_transformer = Dummy()
 
         # Run
+        dummy_transformer.set_random_state(np.random.RandomState(42), 'transform')
         transformed_data = dummy_transformer.transform(data)
 
         # Assert
@@ -1050,6 +1045,7 @@ class TestBaseTransformer:
         dummy_transformer = Dummy()
 
         # Run
+        dummy_transformer.set_random_state(np.random.RandomState(42), 'transform')
         transformed_data = dummy_transformer.transform(data)
 
         # Assert
@@ -1145,6 +1141,7 @@ class TestBaseTransformer:
         dummy_transformer = Dummy()
 
         # Run
+        dummy_transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
         transformed_data = dummy_transformer.reverse_transform(data)
 
         # Assert
@@ -1175,6 +1172,7 @@ class TestBaseTransformer:
 
         # Run
         dummy_transformer = Dummy()
+        dummy_transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
         transformed_data = dummy_transformer.reverse_transform(data)
 
         # Assert


### PR DESCRIPTION
Resolve #639.

It also changes the behavior of the randomization. The `fit` random state is set during initialization, while the `transform` and `reverse_transform` states are only set after seeing the data provided to `fit`. `reset_randomization` returns the random states to the one seen during `fit`. 