### PR TITLE
Update the default transformers that HyperTransformer assigns to each sdtype

### DIFF
--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -112,7 +112,6 @@ class HyperTransformer:
     def __init__(self):
         self.field_sdtypes = {}
         self.field_transformers = {}
-
         self._specified_fields = set()
         self._validate_field_transformers()
         self._valid_output_sdtypes = self._DEFAULT_OUTPUT_SDTYPES

--- a/rdt/hyper_transformer.py
+++ b/rdt/hyper_transformer.py
@@ -110,7 +110,6 @@ class HyperTransformer:
             self._add_field_to_set(field, self._specified_fields)
 
     def __init__(self):
-        self._default_sdtype_transformers = {}
         self.field_sdtypes = {}
         self.field_transformers = {}
 
@@ -489,11 +488,7 @@ class HyperTransformer:
                 self._set_field_sdtype(data, field)
             if field not in self.field_transformers:
                 sdtype = self.field_sdtypes[field]
-                if sdtype in self._default_sdtype_transformers:
-                    self.field_transformers[field] = deepcopy(
-                        self._default_sdtype_transformers[sdtype])
-                else:
-                    self.field_transformers[field] = deepcopy(get_default_transformer(sdtype))
+                self.field_transformers[field] = deepcopy(get_default_transformer(sdtype))
 
     def detect_initial_config(self, data):
         """Print the configuration of the data.
@@ -508,7 +503,6 @@ class HyperTransformer:
                 Data which will have its configuration detected.
         """
         # Reset the state of the HyperTransformer
-        self._default_sdtype_transformers = {}
         self.field_sdtypes = {}
         self.field_transformers = {}
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -99,6 +99,7 @@ DEFAULT_TRANSFORMERS = {
         missing_value_replacement='mean',
         missing_value_generation='random',
     ),
+    'id': RegexGenerator(),
     'pii': AnonymizedFaker(),
 }
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -87,19 +87,11 @@ TRANSFORMERS = {
 
 
 DEFAULT_TRANSFORMERS = {
-    'numerical': FloatFormatter(
-        learn_rounding_scheme=False,
-        enforce_min_max_values=False,
-        missing_value_replacement='mean',
-        missing_value_generation='random',
-    ),
+    'numerical': FloatFormatter(),
     'categorical': LabelEncoder(add_noise=True),
     'boolean': LabelEncoder(add_noise=True),
-    'datetime': UnixTimestampEncoder(
-        missing_value_replacement='mean',
-        missing_value_generation='random',
-    ),
-    'id': RegexGenerator(),
+    'datetime': UnixTimestampEncoder(),
+    'text': RegexGenerator(),
     'pii': AnonymizedFaker(),
 }
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -87,10 +87,19 @@ TRANSFORMERS = {
 
 
 DEFAULT_TRANSFORMERS = {
-    'numerical': FloatFormatter(),
-    'categorical': FrequencyEncoder(),
-    'boolean': BinaryEncoder(),
-    'datetime': UnixTimestampEncoder(),
+    'numerical': FloatFormatter(
+        learn_rounding_scheme=False,
+        enforce_min_max_values=False,
+        missing_value_replacement='mean',
+        missing_value_generation='random',
+    ),
+    'categorical': LabelEncoder(add_noise=True),
+    'boolean': LabelEncoder(add_noise=True),
+    'datetime': UnixTimestampEncoder(
+        missing_value_replacement='mean',
+        missing_value_generation='random',
+    ),
+    'pii': AnonymizedFaker(),
 }
 
 

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -439,6 +439,7 @@ class LabelEncoder(BaseTransformer):
     SUPPORTED_SDTYPES = ['categorical', 'boolean']
     values_to_categories = None
     categories_to_values = None
+    dtype = 'O'
 
     def __init__(self, add_noise=False, order_by=None):
         super().__init__()
@@ -483,6 +484,7 @@ class LabelEncoder(BaseTransformer):
             data (pandas.Series):
                 Data to fit the transformer to.
         """
+        self.dtype = data.dtype
         unique_data = pd.unique(data.fillna(np.nan))
         unique_data = self._order_categories(unique_data)
         self.values_to_categories = dict(enumerate(unique_data))
@@ -524,6 +526,7 @@ class LabelEncoder(BaseTransformer):
         )
 
         if self.add_noise:
+            mapped = mapped.astype(float)
             mapped = np.random.uniform(mapped, mapped + 1)
 
         return mapped
@@ -542,7 +545,9 @@ class LabelEncoder(BaseTransformer):
             data = np.floor(data)
 
         data = data.clip(min(self.values_to_categories), max(self.values_to_categories))
-        return data.round().map(self.values_to_categories)
+        data = data.round().map(self.values_to_categories)
+
+        return data.astype(self.dtype)
 
 
 class OrderedLabelEncoder(LabelEncoder):

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -92,16 +92,25 @@ def get_transformed_data():
     return pd.DataFrame({
         'integer': [1., 2., 1., 3., 1., 4., 2., 3.],
         'float': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
-        'categorical': [0.3125, 0.3125, .8125, 0.8125, 0.3125, 0.8125, 0.3125, 0.3125],
-        'bool': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+        'categorical': [
+            0.9690758764963199, 0.8816575994729887, 1.1326495454234662, 1.7988488918189502,
+            0.9265972159030215, 1.885454600378942, 0.9280858691537548, 0.5093227924068265
+        ],
+        'bool': [
+            0.26161253184788935, 0.5735484647493089, 0.026673806296574787, 1.197229599974477,
+            0.8860641570557322, 0.33432787358513416, 1.1089412122841389, 0.6182653878449814
+        ],
         'datetime': datetimes,
-        'names': [0.3125, 0.75, 0.75, 0.3125, 0.3125, 0.9375, 0.3125, 0.3125]
+        'names': [
+            0.24180193241041126, 1.9297787196579723, 1.5617500744772101, 0.6811042561384157,
+            0.48017218468846856, 2.2867787591284823, 0.25476586891248476, 0.620052082101593
+        ]
     }, index=TEST_DATA_INDEX)
 
 
 def get_reversed_data():
     data = get_input_data()
-    data['bool'] = data['bool'].astype('object')
+
     return data
 
 
@@ -161,10 +170,19 @@ def test_hypertransformer_default_inputs():
     expected_transformed = pd.DataFrame({
         'integer': [1., 2., 1., 3., 1., 4., 2., 3.],
         'float': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
-        'categorical': [0.3125, 0.3125, 0.9375, 0.75, 0.3125, 0.75, 0.3125, 0.3125],
-        'bool': [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+        'categorical': [
+            0.9690758764963199, 0.8816575994729887, 1.1326495454234662, 2.7988488918189502,
+            0.9265972159030215, 2.8854546003789423, 0.9280858691537548, 0.5093227924068265
+        ],
+        'bool': [
+            0.26161253184788935, 1.573548464749309, 0.026673806296574787, 2.1972295999744773,
+            0.8860641570557322, 1.334327873585134, 2.108941212284139, 0.6182653878449814
+        ],
         'datetime': expected_datetimes,
-        'names': [0.3125, 0.75, 0.75, 0.3125, 0.3125, 0.9375, 0.3125, 0.3125]
+        'names': [
+            0.24180193241041126, 1.9297787196579723, 1.5617500744772101, 0.6811042561384157,
+            0.48017218468846856, 2.2867787591284823, 0.25476586891248476, 0.620052082101593
+        ]
     }, index=TEST_DATA_INDEX)
     pd.testing.assert_frame_equal(transformed, expected_transformed)
 
@@ -194,10 +212,10 @@ def test_hypertransformer_default_inputs():
 
     assert isinstance(ht.field_transformers['integer'], FloatFormatter)
     assert isinstance(ht.field_transformers['float'], FloatFormatter)
-    assert isinstance(ht.field_transformers['categorical'], FrequencyEncoder)
-    assert isinstance(ht.field_transformers['bool'], BinaryEncoder)
+    assert isinstance(ht.field_transformers['categorical'], LabelEncoder)
+    assert isinstance(ht.field_transformers['bool'], LabelEncoder)
     assert isinstance(ht.field_transformers['datetime'], UnixTimestampEncoder)
-    assert isinstance(ht.field_transformers['names'], FrequencyEncoder)
+    assert isinstance(ht.field_transformers['names'], LabelEncoder)
 
     get_default_transformers.cache_clear()
     get_default_transformer.cache_clear()
@@ -236,10 +254,10 @@ def test_hypertransformer_field_transformers():
         'transformers': {
             'integer': FloatFormatter(missing_value_replacement='mean'),
             'float': FloatFormatter(missing_value_replacement='mean'),
-            'categorical': FrequencyEncoder(),
-            'bool': BinaryEncoder(missing_value_replacement='mode'),
+            'categorical': LabelEncoder(add_noise=True),
+            'bool': LabelEncoder(add_noise=True),
             'datetime': DummyTransformerNotMLReady(),
-            'names': FrequencyEncoder()
+            'names': LabelEncoder(add_noise=True)
         }
     }
 

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -216,6 +216,8 @@ class TestHyperTransformer(TestCase):
         """
         # Setup
         data = self.get_data()
+        data['pii'] = ['a', 'b', 'c', 'd']
+        data['id'] = ['e', 'f', 'g', 'h']
         field_transformers = {
             'integer': FloatFormatter(),
             'float': ClusterBasedNormalizer(),
@@ -224,10 +226,16 @@ class TestHyperTransformer(TestCase):
             LabelEncoder(),
             LabelEncoder(),
             UnixTimestampEncoder(),
+            AnonymizedFaker(),
+            RegexGenerator(),
         ]
         ht = HyperTransformer()
         ht.field_transformers = field_transformers
-        ht.field_sdtypes = {'datetime': 'datetime'}
+        ht.field_sdtypes = {
+            'datetime': 'datetime',
+            'pii': 'pii',
+            'id': 'id'
+        }
         ht._unfit = Mock()
 
         # Run
@@ -239,7 +247,9 @@ class TestHyperTransformer(TestCase):
             'float': 'numerical',
             'bool': 'boolean',
             'categorical': 'categorical',
-            'datetime': 'datetime'
+            'datetime': 'datetime',
+            'pii': 'pii',
+            'id': 'id'
         }
 
         assert isinstance(ht.field_transformers['integer'], FloatFormatter)
@@ -247,6 +257,8 @@ class TestHyperTransformer(TestCase):
         assert isinstance(ht.field_transformers['categorical'], LabelEncoder)
         assert isinstance(ht.field_transformers['bool'], LabelEncoder)
         assert isinstance(ht.field_transformers['datetime'], UnixTimestampEncoder)
+        assert isinstance(ht.field_transformers['pii'], AnonymizedFaker)
+        assert isinstance(ht.field_transformers['id'], RegexGenerator)
         ht._unfit.assert_called_once()
 
     @patch('rdt.hyper_transformer.LOGGER')

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -217,7 +217,7 @@ class TestHyperTransformer(TestCase):
         # Setup
         data = self.get_data()
         data['pii'] = ['a', 'b', 'c', 'd']
-        data['id'] = ['e', 'f', 'g', 'h']
+        data['text'] = ['e', 'f', 'g', 'h']
         field_transformers = {
             'integer': FloatFormatter(),
             'float': ClusterBasedNormalizer(),
@@ -234,7 +234,7 @@ class TestHyperTransformer(TestCase):
         ht.field_sdtypes = {
             'datetime': 'datetime',
             'pii': 'pii',
-            'id': 'id'
+            'text': 'text'
         }
         ht._unfit = Mock()
 
@@ -249,7 +249,7 @@ class TestHyperTransformer(TestCase):
             'categorical': 'categorical',
             'datetime': 'datetime',
             'pii': 'pii',
-            'id': 'id'
+            'text': 'text',
         }
 
         assert isinstance(ht.field_transformers['integer'], FloatFormatter)
@@ -258,7 +258,7 @@ class TestHyperTransformer(TestCase):
         assert isinstance(ht.field_transformers['bool'], LabelEncoder)
         assert isinstance(ht.field_transformers['datetime'], UnixTimestampEncoder)
         assert isinstance(ht.field_transformers['pii'], AnonymizedFaker)
-        assert isinstance(ht.field_transformers['id'], RegexGenerator)
+        assert isinstance(ht.field_transformers['text'], RegexGenerator)
         ht._unfit.assert_called_once()
 
     @patch('rdt.hyper_transformer.LOGGER')

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -108,7 +108,6 @@ class TestHyperTransformer(TestCase):
 
         # Asserts
         assert ht.field_sdtypes == {}
-        assert ht._default_sdtype_transformers == {}
         assert ht.field_transformers == {}
         assert ht._specified_fields == set()
         assert ht._valid_output_sdtypes == ht._DEFAULT_OUTPUT_SDTYPES
@@ -221,15 +220,14 @@ class TestHyperTransformer(TestCase):
             'integer': FloatFormatter(),
             'float': ClusterBasedNormalizer(),
         }
-        default_sdtype_transformers = {
-            'boolean': BinaryEncoder(),
-            'categorical': FrequencyEncoder()
-        }
-        get_default_transformer_mock.return_value = UnixTimestampEncoder()
+        get_default_transformer_mock.side_effect = [
+            LabelEncoder(),
+            LabelEncoder(),
+            UnixTimestampEncoder(),
+        ]
         ht = HyperTransformer()
         ht.field_transformers = field_transformers
         ht.field_sdtypes = {'datetime': 'datetime'}
-        ht._default_sdtype_transformers = default_sdtype_transformers
         ht._unfit = Mock()
 
         # Run
@@ -246,8 +244,8 @@ class TestHyperTransformer(TestCase):
 
         assert isinstance(ht.field_transformers['integer'], FloatFormatter)
         assert isinstance(ht.field_transformers['float'], ClusterBasedNormalizer)
-        assert isinstance(ht.field_transformers['categorical'], FrequencyEncoder)
-        assert isinstance(ht.field_transformers['bool'], BinaryEncoder)
+        assert isinstance(ht.field_transformers['categorical'], LabelEncoder)
+        assert isinstance(ht.field_transformers['bool'], LabelEncoder)
         assert isinstance(ht.field_transformers['datetime'], UnixTimestampEncoder)
         ht._unfit.assert_called_once()
 

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -286,8 +286,8 @@ class TestHyperTransformer(TestCase):
         field_transformers = {k: repr(v) for (k, v) in ht.field_transformers.items()}
         assert field_transformers == {
             'col1': 'FloatFormatter()',
-            'col2': 'FrequencyEncoder()',
-            'col3': 'BinaryEncoder()',
+            'col2': 'LabelEncoder(add_noise=True)',
+            'col3': 'LabelEncoder(add_noise=True)',
             'col4': 'UnixTimestampEncoder()',
             'col5': 'FloatFormatter()'
         }
@@ -303,8 +303,8 @@ class TestHyperTransformer(TestCase):
             '    },',
             '    "transformers": {',
             '        "col1": FloatFormatter(),',
-            '        "col2": FrequencyEncoder(),',
-            '        "col3": BinaryEncoder(),',
+            '        "col2": LabelEncoder(add_noise=True),',
+            '        "col3": LabelEncoder(add_noise=True),',
             '        "col4": UnixTimestampEncoder(),',
             '        "col5": FloatFormatter()',
             '    }',

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -116,6 +116,5 @@ def test_get_default_transformers():
         'pii': AnonymizedFaker,
     }
 
-    # Assert
     for sdtype, transformer in expected_dict.items():
         assert isinstance(default_transformer_dict[sdtype], transformer)

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -1,6 +1,8 @@
 import pytest
 
-from rdt.transformers import BinaryEncoder, get_transformer_class, get_transformer_name
+from rdt.transformers import (
+    AnonymizedFaker, BinaryEncoder, FloatFormatter, LabelEncoder, RegexGenerator,
+    UnixTimestampEncoder, get_default_transformers, get_transformer_class, get_transformer_name)
 from rdt.transformers.addons.identity.identity import IdentityTransformer
 
 
@@ -94,3 +96,26 @@ def test_get_transformer_class_transformer_path_addon():
 
     # Assert
     assert returned == IdentityTransformer
+
+
+def test_get_default_transformers():
+    """Test the ``get_default_transformers`` method.
+
+    Check that the right default transformer is returned for each type.
+    """
+    # Run
+    default_transformer_dict = get_default_transformers()
+
+    # Assert
+    expected_dict = {
+        'numerical': FloatFormatter,
+        'categorical': LabelEncoder,
+        'boolean': LabelEncoder,
+        'datetime': UnixTimestampEncoder,
+        'id': RegexGenerator,
+        'pii': AnonymizedFaker,
+    }
+
+    # Assert
+    for sdtype, transformer in expected_dict.items():
+        assert isinstance(default_transformer_dict[sdtype], transformer)

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -112,7 +112,7 @@ def test_get_default_transformers():
         'categorical': LabelEncoder,
         'boolean': LabelEncoder,
         'datetime': UnixTimestampEncoder,
-        'id': RegexGenerator,
+        'text': RegexGenerator,
         'pii': AnonymizedFaker,
     }
 


### PR DESCRIPTION
Resolve #664 

Few things about this PR.
- I removed the `_default_sdtype_transformers` of the `HyperTransformer` because it was never used. Maybe we want to define it properly and use it.
- I added the `dtype` attribute similar to the one of the `FrequencyEncoder`, so now the `LabelEncoder` can work with pandas `category` type. This also ensures that boolean columns are reverse-transformed to booleans as well.