### PR TITLE
Add UniformEncoder (and its ordered version)

### DIFF
--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -12,7 +12,8 @@ from pathlib import Path
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.boolean import BinaryEncoder
 from rdt.transformers.categorical import (
-    CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder)
+    CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder,
+    OrderedUniformEncoder, UniformEncoder)
 from rdt.transformers.datetime import OptimizedTimestampEncoder, UnixTimestampEncoder
 from rdt.transformers.null import NullTransformer
 from rdt.transformers.numerical import ClusterBasedNormalizer, FloatFormatter, GaussianNormalizer
@@ -41,6 +42,8 @@ __all__ = [
     'get_transformers_by_type',
     'get_default_transformers',
     'get_default_transformer',
+    'UniformEncoder',
+    'OrderedUniformEncoder',
 ]
 
 

--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -91,8 +91,8 @@ TRANSFORMERS = {
 
 DEFAULT_TRANSFORMERS = {
     'numerical': FloatFormatter(),
-    'categorical': LabelEncoder(add_noise=True),
-    'boolean': LabelEncoder(add_noise=True),
+    'categorical': UniformEncoder(),
+    'boolean': UniformEncoder(),
     'datetime': UnixTimestampEncoder(),
     'text': RegexGenerator(),
     'pii': AnonymizedFaker(),

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -264,7 +264,10 @@ class OrderedUniformEncoder(UniformEncoder):
         else:
             freq = data.value_counts(normalize=True, dropna=False)
 
+        nan_value = freq[np.nan] if np.nan in freq.index else None
         freq = freq.reindex(self.order).array
+        freq[np.isnan(freq)] = nan_value
+
         self.frequencies, self.intervals = self._compute_frequencies_intervals(self.order, freq)
 
     def _transform(self, data):

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -163,7 +163,7 @@ class UniformEncoder(BaseTransformer):
         def map_labels(label):
             return np.random.uniform(self.intervals[label][0], self.intervals[label][1])
 
-        return data_with_none.map(map_labels)
+        return data_with_none.map(map_labels).astype(float)
 
     def _reverse_transform(self, data):
         """Convert float values back to the original categorical values.

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -126,7 +126,11 @@ class UniformEncoder(BaseTransformer):
         data = fill_nan_with_none(data)
         labels = pd.unique(data)
         labels = self._order_categories(labels)
-        freq = data.value_counts(normalize=True, dropna=False).reindex(labels).array
+        freq = data.value_counts(normalize=True, dropna=False)
+        nan_value = freq[np.nan] if np.nan in freq.index else None
+        freq = freq.reindex(labels).array
+        freq[np.isnan(freq)] = nan_value
+
         self.frequencies, self.intervals = self._compute_frequencies_intervals(labels, freq)
 
     def _transform(self, data):

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -1,5 +1,6 @@
 """Transformers for categorical data."""
 
+import logging
 import warnings
 
 import numpy as np
@@ -9,6 +10,268 @@ from scipy.stats import norm
 
 from rdt.errors import TransformerInputError
 from rdt.transformers.base import BaseTransformer
+from rdt.transformers.utils import fill_nan_with_none
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UniformEncoder(BaseTransformer):
+    """Transformer for categorical data.
+
+    This transformer computes a float representative for each one of the categories
+    found in the fit data, and then replaces the instances of these categories with
+    the corresponding representative.
+
+    The representatives are decided by computing the frequencies of each labels and
+    then dividing the ``[0, 1]`` interval according to these frequencies.
+
+    When the transformation is reverted, each value is assigned the category that
+    corresponds to the interval it falls in.
+
+    Null values are considered just another category.
+
+    Args:
+        order_by (str or None):
+            String defining how to order the data before applying the labels. Options are
+            'alphabetical', 'numerical' and ``None``. Defaults to ``None``.
+    """
+
+    INPUT_SDTYPE = 'categorical'
+    SUPPORTED_SDTYPES = ['categorical', 'boolean']
+    frequencies = None
+    intervals = None
+    dtype = None
+
+    def __init__(self, order_by=None):
+        super().__init__()
+        if order_by not in [None, 'alphabetical', 'numerical_value']:
+            raise TransformerInputError(
+                "order_by must be one of the following values: None, 'numerical_value' or "
+                "'alphabetical'"
+            )
+
+        self.order_by = order_by
+
+    def _order_categories(self, unique_data):
+        nans = pd.isna(unique_data)
+        if self.order_by == 'alphabetical':
+            # pylint: disable=invalid-unary-operand-type
+            if any(map(lambda item: not isinstance(item, str), unique_data[~nans])):
+                raise TransformerInputError(
+                    "The data must be of type string if order_by is 'alphabetical'."
+                )
+        elif self.order_by == 'numerical_value':
+            if not np.issubdtype(unique_data.dtype.type, np.number):
+                raise TransformerInputError(
+                    "The data must be numerical if order_by is 'numerical_value'."
+                )
+
+        if self.order_by is not None:
+            unique_data = np.sort(unique_data[~nans])  # pylint: disable=invalid-unary-operand-type
+            if nans.any():
+                unique_data = np.append(unique_data, [None])
+
+        return unique_data
+
+    @classmethod
+    def _get_message_unseen_categories(cls, unseen_categories):
+        """Message to raise when there is unseen categories.
+
+        Args:
+            unseen_categories (list): list of unseen categories
+
+        Returns:
+            message to print
+        """
+        categories_to_print = ', '.join(str(x) for x in unseen_categories[:3])
+        if len(unseen_categories) > 3:
+            categories_to_print = f'{categories_to_print}, +{len(unseen_categories) - 3} more'
+
+        return categories_to_print
+
+    @staticmethod
+    def _compute_frequencies_intervals(categories, freq):
+        """Compute the frequencies and intervals of the categories.
+
+        Args:
+            categories (list):
+                List of categories.
+            freq (list):
+                List of frequencies.
+
+        Returns:
+            tuple[dict, dict]:
+                First dict maps categories to their frequency and the
+                second dict maps the categories to their intervals.
+        """
+        frequencies = dict(zip(categories, freq))
+        shift = np.cumsum(np.hstack([0, freq]))
+        shift[-1] = 1
+        list_int = [[shift[i], shift[i + 1]] for i in range(len(shift) - 1)]
+        intervals = dict(zip(categories, list_int))
+
+        return frequencies, intervals
+
+    def _fit(self, data):
+        """Fit the transformer to the data.
+
+        Compute the frequencies of each category and use them
+        to map the column to a numerical one.
+
+        Args:
+            data (pandas.Series):
+                Data to fit the transformer to.
+        """
+        self.dtype = data.dtypes
+        data = fill_nan_with_none(data)
+        labels = pd.unique(data)
+        labels = self._order_categories(labels)
+        freq = data.value_counts(normalize=True, dropna=False).reindex(labels).array
+        self.frequencies, self.intervals = self._compute_frequencies_intervals(labels, freq)
+
+    def _transform(self, data):
+        """Map the category to a continuous value.
+
+        This value is sampled from a uniform distribution
+        with boudaries defined by the frequencies.
+
+        Args:
+            data (pandas.Series):
+                Data to transform.
+
+        Returns:
+            pandas.Series
+        """
+        data_with_none = fill_nan_with_none(data)
+        unseen_indexes = ~(data_with_none.isin(self.frequencies))
+        if unseen_indexes.any():
+            # Keep the 3 first unseen categories
+            unseen_categories = list(data.loc[unseen_indexes].unique())
+            categories_to_print = self._get_message_unseen_categories(unseen_categories)
+            warnings.warn(
+                f"The data in column '{self.get_input_column()}' contains new categories "
+                f"that did not appear during 'fit' ({categories_to_print}). Assigning "
+                'them random values. If you want to model new categories, '
+                "please fit the data again using 'fit'.",
+                category=UserWarning
+            )
+
+            choices = list(self.frequencies.keys())
+            size = unseen_indexes.size
+            data_with_none[unseen_indexes] = np.random.choice(choices, size=size)
+
+        def map_labels(label):
+            return np.random.uniform(self.intervals[label][0], self.intervals[label][1])
+
+        return data_with_none.map(map_labels)
+
+    def _reverse_transform(self, data):
+        """Convert float values back to the original categorical values.
+
+        Args:
+            data (pandas.Series):
+                Data to revert.
+
+        Returns:
+            pandas.Series
+        """
+        data = data.clip(0, 1)
+        bins = [0]
+        labels = []
+        nan_name = 'NaN'
+        while nan_name in self.intervals.keys():
+            nan_name += '_'
+
+        for key, interval in self.intervals.items():
+            bins.append(interval[1])
+            if pd.isna(key):
+                labels.append(nan_name)
+            else:
+                labels.append(key)
+
+        result = pd.cut(data, bins=bins, labels=labels)
+        return result.replace(nan_name, np.nan).astype(self.dtype)
+
+
+class OrderedUniformEncoder(UniformEncoder):
+    """Ordered uniform encoder for categorical data.
+
+    This class works very similarly to the ``UniformEncoder``, except that it requires the ordering
+    for the labels to be provided.
+    Null values are considered just another category.
+
+    Args:
+        order (list):
+            A list of all the unique categories for the data. The order of the list determines the
+            label that each category will get.
+    """
+
+    def __init__(self, order):
+        self.order = fill_nan_with_none(pd.Series(order))
+        super().__init__()
+
+    def __repr__(self):
+        """Represent initialization of transformer as text.
+
+        Returns:
+            str:
+                The name of the transformer followed by any non-default parameters.
+        """
+        class_name = self.__class__.get_name()
+        custom_args = ['order=<CUSTOM>']
+        args_string = ', '.join(custom_args)
+        return f'{class_name}({args_string})'
+
+    def _check_unknown_categories(self, data):
+        missing = list(data[~data.isin(self.order)].unique())
+        if len(missing) > 0:
+            raise TransformerInputError(
+                f"Unknown categories '{missing}'. All possible categories must be defined in the "
+                "'order' parameter."
+            )
+
+    def _fit(self, data):
+        """Fit the transformer to the data.
+
+        Create all the class attributes while respecting the speicified
+        order of the labels.
+
+        Args:
+            data (pandas.Series):
+                Data to fit the transformer to.
+        """
+        self.dtype = data.dtypes
+        data = fill_nan_with_none(data)
+        self._check_unknown_categories(data)
+
+        category_not_seen = (set(self.order.dropna()) != set(data.dropna()))
+        nans_not_seen = (pd.isna(self.order).any() and not pd.isna(data).any())
+        if category_not_seen or nans_not_seen:
+            unseen_categories = [x for x in self.order if x not in data.array]
+            categories_to_print = self._get_message_unseen_categories(unseen_categories)
+            LOGGER.info(
+                "For column '%s', some of the provided category values were not present in the"
+                ' data during fit: (%s).',
+                self.get_input_column(),
+                categories_to_print
+            )
+
+            freq = data.value_counts(normalize=True, dropna=False)
+            freq = 0.9 * freq
+            for category in unseen_categories:
+                freq[category] = 0.1 / len(unseen_categories)
+
+        else:
+            freq = data.value_counts(normalize=True, dropna=False)
+
+        freq = freq.reindex(self.order).array
+        self.frequencies, self.intervals = self._compute_frequencies_intervals(self.order, freq)
+
+    def _transform(self, data):
+        """Map the category to a continuous value."""
+        data = fill_nan_with_none(data)
+        self._check_unknown_categories(data)
+        return super()._transform(data)
 
 
 class FrequencyEncoder(BaseTransformer):

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -150,3 +150,16 @@ def strings_from_regex(regex, max_repeat=16):
             sizes.append(size)
 
     return _from_generators(generators, max_repeat), np.prod(sizes, dtype=np.complex128)
+
+
+def fill_nan_with_none(data):
+    """Replace all nan values with None.
+
+    Args:
+        data (pd.DataFrame or pd.Series)
+
+    Returns:
+        data:
+            Original data with nan values replaced by None.
+    """
+    return data.fillna(np.nan).replace([np.nan], [None])

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -10,8 +10,8 @@ from rdt import HyperTransformer, get_demo
 from rdt.errors import ConfigNotSetError, InvalidConfigError, InvalidDataError, NotFittedError
 from rdt.transformers import (
     AnonymizedFaker, BaseTransformer, BinaryEncoder, ClusterBasedNormalizer, FloatFormatter,
-    FrequencyEncoder, LabelEncoder, OneHotEncoder, RegexGenerator, UnixTimestampEncoder,
-    get_default_transformer, get_default_transformers)
+    FrequencyEncoder, LabelEncoder, OneHotEncoder, RegexGenerator, UniformEncoder,
+    UnixTimestampEncoder, get_default_transformer, get_default_transformers)
 from rdt.transformers.datetime import OptimizedTimestampEncoder
 from rdt.transformers.numerical import GaussianNormalizer
 from rdt.transformers.pii.anonymizer import PseudoAnonymizedFaker
@@ -93,17 +93,17 @@ def get_transformed_data():
         'integer': [1., 2., 1., 3., 1., 4., 2., 3.],
         'float': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
         'categorical': [
-            0.9690758764963199, 0.8816575994729887, 1.1326495454234662, 1.7988488918189502,
-            0.9265972159030215, 1.885454600378942, 0.9280858691537548, 0.5093227924068265
+            0.6056724228102, 0.551035999670618, 0.6747435795337998, 0.9245683344321064,
+            0.5791232599393884, 0.9570454751421033, 0.5800536682210967, 0.3183267452542666
         ],
         'bool': [
-            0.26161253184788935, 0.5735484647493089, 0.026673806296574787, 1.197229599974477,
-            0.8860641570557322, 0.33432787358513416, 1.1089412122841389, 0.6182653878449814
+            0.196209398885917, 0.4301613485619816, 0.02000535472243109, 0.7993073999936193,
+            0.6645481177917991, 0.25074590518885065, 0.7772353030710347, 0.46369904088373604
         ],
         'datetime': datetimes,
         'names': [
-            0.24180193241041126, 1.9297787196579723, 1.5617500744772101, 0.6811042561384157,
-            0.48017218468846856, 2.2867787591284823, 0.25476586891248476, 0.620052082101593
+            0.15112620775650704, 0.857444679914493, 0.7654375186193025, 0.42569016008650984,
+            0.30010761543029285, 0.9108473448910603, 0.15922866807030298, 0.3875325513134956
         ]
     }, index=TEST_DATA_INDEX)
 
@@ -171,17 +171,17 @@ def test_hypertransformer_default_inputs():
         'integer': [1., 2., 1., 3., 1., 4., 2., 3.],
         'float': [0.1, 0.2, 0.1, 0.2, 0.1, 0.4, 0.2, 0.3],
         'categorical': [
-            0.9690758764963199, 0.8816575994729887, 1.1326495454234662, 2.7988488918189502,
-            0.9265972159030215, 2.8854546003789423, 0.9280858691537548, 0.5093227924068265
+            0.6056724228102, 0.551035999670618, 0.6415811931779333, 0.9497122229547376,
+            0.5791232599393884, 0.9713636500947356, 0.5800536682210967, 0.3183267452542666
         ],
         'bool': [
-            0.26161253184788935, 1.573548464749309, 0.026673806296574787, 2.1972295999744773,
-            0.8860641570557322, 1.334327873585134, 2.108941212284139, 0.6182653878449814
+            0.13080626592394468, 0.6433871161873272, 0.013336903148287393, 0.7993073999936193,
+            0.4430320785278661, 0.5835819683962835, 0.7772353030710347, 0.3091326939224907
         ],
         'datetime': expected_datetimes,
         'names': [
-            0.24180193241041126, 1.9297787196579723, 1.5617500744772101, 0.6811042561384157,
-            0.48017218468846856, 2.2867787591284823, 0.25476586891248476, 0.620052082101593
+            0.15112620775650704, 0.857444679914493, 0.7654375186193025, 0.42569016008650984,
+            0.30010761543029285, 0.9108473448910603, 0.15922866807030298, 0.3875325513134956
         ]
     }, index=TEST_DATA_INDEX)
     pd.testing.assert_frame_equal(transformed, expected_transformed)
@@ -212,10 +212,10 @@ def test_hypertransformer_default_inputs():
 
     assert isinstance(ht.field_transformers['integer'], FloatFormatter)
     assert isinstance(ht.field_transformers['float'], FloatFormatter)
-    assert isinstance(ht.field_transformers['categorical'], LabelEncoder)
-    assert isinstance(ht.field_transformers['bool'], LabelEncoder)
+    assert isinstance(ht.field_transformers['categorical'], UniformEncoder)
+    assert isinstance(ht.field_transformers['bool'], UniformEncoder)
     assert isinstance(ht.field_transformers['datetime'], UnixTimestampEncoder)
-    assert isinstance(ht.field_transformers['names'], LabelEncoder)
+    assert isinstance(ht.field_transformers['names'], UniformEncoder)
 
     get_default_transformers.cache_clear()
     get_default_transformer.cache_clear()
@@ -254,10 +254,10 @@ def test_hypertransformer_field_transformers():
         'transformers': {
             'integer': FloatFormatter(missing_value_replacement='mean'),
             'float': FloatFormatter(missing_value_replacement='mean'),
-            'categorical': LabelEncoder(add_noise=True),
-            'bool': LabelEncoder(add_noise=True),
+            'categorical': UniformEncoder(),
+            'bool': UniformEncoder(),
             'datetime': DummyTransformerNotMLReady(),
-            'names': LabelEncoder(add_noise=True)
+            'names': UniformEncoder()
         }
     }
 

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -67,7 +67,10 @@ def _validate_helper(validator_function, args, steps):
 
 def _is_valid_transformer(transformer_name):
     """Determine if transformer should be tested or not."""
-    invalid_names = ['IdentityTransformer', 'Dummy', 'OrderedLabelEncoder', 'CustomLabelEncoder']
+    invalid_names = [
+        'IdentityTransformer', 'Dummy', 'OrderedLabelEncoder', 'CustomLabelEncoder',
+        'OrderedUniformEncoder',
+    ]
     return all(invalid_name not in transformer_name for invalid_name in invalid_names)
 
 

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -8,10 +8,12 @@ from rdt.performance.datasets import get_dataset_generators_by_type
 from rdt.performance.performance import evaluate_transformer_performance
 from rdt.performance.profiling import profile_transformer
 from rdt.transformers import get_transformers_by_type
-from rdt.transformers.categorical import CustomLabelEncoder, OrderedLabelEncoder
+from rdt.transformers.categorical import CustomLabelEncoder, OrderedLabelEncoder, OrderedUniformEncoder
 from rdt.transformers.numerical import ClusterBasedNormalizer
 
-SANDBOX_TRANSFORMERS = [ClusterBasedNormalizer, OrderedLabelEncoder, CustomLabelEncoder]
+SANDBOX_TRANSFORMERS = [
+    ClusterBasedNormalizer, OrderedLabelEncoder, CustomLabelEncoder, OrderedUniformEncoder
+]
 
 
 def _get_performance_test_cases():

--- a/tests/performance/test_performance.py
+++ b/tests/performance/test_performance.py
@@ -8,7 +8,8 @@ from rdt.performance.datasets import get_dataset_generators_by_type
 from rdt.performance.performance import evaluate_transformer_performance
 from rdt.performance.profiling import profile_transformer
 from rdt.transformers import get_transformers_by_type
-from rdt.transformers.categorical import CustomLabelEncoder, OrderedLabelEncoder, OrderedUniformEncoder
+from rdt.transformers.categorical import (
+    CustomLabelEncoder, OrderedLabelEncoder, OrderedUniformEncoder)
 from rdt.transformers.numerical import ClusterBasedNormalizer
 
 SANDBOX_TRANSFORMERS = [

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -296,8 +296,8 @@ class TestHyperTransformer(TestCase):
         field_transformers = {k: repr(v) for (k, v) in ht.field_transformers.items()}
         assert field_transformers == {
             'col1': 'FloatFormatter()',
-            'col2': 'LabelEncoder(add_noise=True)',
-            'col3': 'LabelEncoder(add_noise=True)',
+            'col2': 'UniformEncoder()',
+            'col3': 'UniformEncoder()',
             'col4': 'UnixTimestampEncoder()',
             'col5': 'FloatFormatter()'
         }
@@ -313,8 +313,8 @@ class TestHyperTransformer(TestCase):
             '    },',
             '    "transformers": {',
             '        "col1": FloatFormatter(),',
-            '        "col2": LabelEncoder(add_noise=True),',
-            '        "col3": LabelEncoder(add_noise=True),',
+            '        "col2": UniformEncoder(),',
+            '        "col3": UniformEncoder(),',
             '        "col4": UnixTimestampEncoder(),',
             '        "col5": FloatFormatter()',
             '    }',

--- a/tests/unit/transformers/test___init__.py
+++ b/tests/unit/transformers/test___init__.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rdt.transformers import (
-    AnonymizedFaker, BinaryEncoder, FloatFormatter, LabelEncoder, RegexGenerator,
+    AnonymizedFaker, BinaryEncoder, FloatFormatter, RegexGenerator, UniformEncoder,
     UnixTimestampEncoder, get_default_transformers, get_transformer_class, get_transformer_name)
 from rdt.transformers.addons.identity.identity import IdentityTransformer
 
@@ -109,8 +109,8 @@ def test_get_default_transformers():
     # Assert
     expected_dict = {
         'numerical': FloatFormatter,
-        'categorical': LabelEncoder,
-        'boolean': LabelEncoder,
+        'categorical': UniformEncoder,
+        'boolean': UniformEncoder,
         'datetime': UnixTimestampEncoder,
         'text': RegexGenerator,
         'pii': AnonymizedFaker,

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -299,19 +299,19 @@ class TestUniformEncoder:
     def test__reverse_transform_nans(self):
         """Test ``_reverse_transform`` for data with NaNs."""
         # Setup
-        data = pd.Series(['a', 'b', 'c', np.nan, 'c', 'b', 'b', 'a', 'b', np.nan])
+        data = pd.Series(['a', 'b', 'NaN', np.nan, 'NaN', 'b', 'b', 'a', 'b', np.nan])
         transformer = UniformEncoder()
         transformer.dtype = object
         transformer.frequencies = {
             'a': 0.2,
             'b': 0.4,
-            'c': 0.2,
+            'NaN': 0.2,
             np.nan: 0.2
         }
         transformer.intervals = {
             'a': [0, 0.2],
             'b': [0.2, 0.6],
-            'c': [0.6, 0.8],
+            'NaN': [0.6, 0.8],
             np.nan: [0.8, 1]
         }
 
@@ -458,16 +458,20 @@ class TestOrderedUniformEncoder:
         If the data being transformed is not in ``self.order`` an error should be raised.
         """
         # Setup
-        data = pd.Series([1, 2, 3, 2, 1, 4])
+        data_error = pd.Series([1, 2, 3, 2, 1, 4])
+        data = pd.Series([1, 2, 1, 2, 1, 1])
         transformer = OrderedUniformEncoder(order=[2, 1])
 
         # Run / Assert
+        transformer._fit(data)
+        transformer._transform(data)
+
         message = re.escape(
             "Unknown categories '[3, 4]'. All possible categories must be defined in the "
             "'order' parameter."
         )
         with pytest.raises(TransformerInputError, match=message):
-            transformer._transform(data)
+            transformer._transform(data_error)
 
 
 class TestFrequencyEncoder:

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -359,38 +359,26 @@ class TestOrderedUniformEncoder:
         assert stringified_transformer == 'OrderedUniformEncoder(order=<CUSTOM>)'
 
     def test__fit(self):
-        """Test the ``_fit`` method.
-
-        Validate that a unique integer representation for each category of the data is stored
-        in the ``categories_to_values`` attribute, and the reverse is stored in the
-        ``values_to_categories`` attribute. The order should match the ``self.order`` indices.
-        Setup:
-            - create an instance of the ``CustomLabelEncoder``.
-        Input:
-            - a pandas series.
-        Side effects:
-            - set the ``values_to_categories`` dictionary to the appropriate value.
-            - set ``categories_to_values`` dictionary to the appropriate value.
-        """
+        """Test the ``_fit`` method."""
         # Setup
-        data = pd.Series([1, 2, 3, 2, np.nan, 1, 1])
-        transformer = OrderedUniformEncoder(order=[2, 3, np.nan, 1])
+        data = pd.Series([1, 2, 3, 2, None, 1, 1])
+        transformer = OrderedUniformEncoder(order=[2, 3, None, 1])
 
         # Run
         transformer._fit(data)
 
         # Assert
         expected_frequencies = {
-            2: 0.2857142857142857,
-            3: 0.14285714285714285,
+            2.0: 0.2857142857142857,
+            3.0: 0.14285714285714285,
             None: 0.14285714285714285,
-            1: 0.42857142857142855
+            1.0: 0.42857142857142855
         }
         expected_intervals = {
-            2: [0.0, 0.2857142857142857],
-            3: [0.2857142857142857, 0.42857142857142855],
+            2.0: [0.0, 0.2857142857142857],
+            3.0: [0.2857142857142857, 0.42857142857142855],
             None: [0.42857142857142855, 0.5714285714285714],
-            1: [0.5714285714285714, 1.0]
+            1.0: [0.5714285714285714, 1.0]
         }
         assert transformer.frequencies == expected_frequencies
         assert transformer.intervals == expected_intervals

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from unittest.mock import Mock, call, patch
 
@@ -7,9 +8,466 @@ import pytest
 
 from rdt.errors import TransformerInputError
 from rdt.transformers.categorical import (
-    CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder)
+    CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder,
+    OrderedUniformEncoder, UniformEncoder)
 
 RE_SSN = re.compile(r'\d\d\d-\d\d-\d\d\d\d')
+
+
+class TestUniformEncoder:
+    """Test class for the UniformEncoder."""
+
+    def test___init___bad_order_by(self):
+        """Test that the ``__init__`` raises error if ``order_by`` is a bad value.
+
+        Input:
+            - ``order_by`` will be set to an unexpected string.
+        Expected behavior:
+            - An error should be raised.
+        """
+        # Run / Assert
+        message = (
+            "order_by must be one of the following values: None, 'numerical_value' or "
+            "'alphabetical'"
+        )
+        with pytest.raises(TransformerInputError, match=message):
+            UniformEncoder(order_by='bad_value')
+
+    def test__order_categories_alphabetical(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'alphabetical'.
+
+        Setup:
+            - Set ``order_by`` to 'alphabetical'.
+        Input:
+            - numpy array of strings that are unordered.
+        Output:
+            - Same numpy array but with the strings alphabetically ordered.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='alphabetical')
+        arr = np.array(['one', 'two', 'three', 'four'])
+
+        # Run
+        ordered = transformer._order_categories(arr)
+
+        # Assert
+        np.testing.assert_array_equal(ordered, np.array(['four', 'one', 'three', 'two']))
+
+    def test__order_categories_alphabetical_with_nans(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'alphabetical'.
+
+        Setup:
+            - Set ``order_by`` to 'alphabetical'.
+        Input:
+            - numpy array of strings that are unordered and have nans.
+        Output:
+            - Same numpy array but with the strings alphabetically ordered and nan at the end.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='alphabetical')
+        arr = np.array(['one', 'two', 'three', np.nan, 'four'], dtype='object')
+
+        # Run
+        ordered = transformer._order_categories(arr)
+
+        # Assert
+        expected = np.array(['four', 'one', 'three', 'two', np.nan], dtype='object')
+        pd.testing.assert_series_equal(pd.Series(ordered), pd.Series(expected))
+
+    def test__order_categories_alphabetical_float_error(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'alphabetical'.
+
+        If ``order_by`` is 'alphabetical' but the data isn't a string, then an error should
+        be raised.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='alphabetical')
+        arr = np.array([1, 2, 3, 4])
+
+        # Run / Assert
+        message = "The data must be of type string if order_by is 'alphabetical'."
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._order_categories(arr)
+
+    def test__order_categories_alphabetical_nonstring_object_error(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'alphabetical'.
+
+        If ``order_by`` is 'alphabetical' and the data's dtype is object but none of the values
+        are strings, then an error should be raised.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='alphabetical')
+        arr = np.array([True, False, None])
+
+        # Run / Assert
+        message = "The data must be of type string if order_by is 'alphabetical'."
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._order_categories(arr)
+
+    def test__order_categories_numerical(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'numerical_value'.
+
+        Setup:
+            - Set ``order_by`` to 'numerical_value'.
+        Input:
+            - numpy array of numbers that are unordered.
+        Output:
+            - Same numpy array but with the numbers ordered.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='numerical_value')
+        arr = np.array([5, 3.11, 100, 67.8, np.nan, -2.5])
+
+        # Run
+        ordered = transformer._order_categories(arr)
+
+        # Assert
+        np.testing.assert_array_equal(ordered, np.array([-2.5, 3.11, 5, 67.8, 100, None]))
+
+    def test__order_categories_numerical_error(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'numerical_value'.
+
+        If the array is made up of strings that can't be converted to floats, and `order_by`
+        is 'numerical_value', then we should raise an error.
+        Setup:
+            - Set ``order_by`` to 'numerical_value'.
+        Input:
+            - numpy array of strings.
+        Expected behavior:
+            - Error should be raised.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='numerical_value')
+        arr = np.array(['one', 'two', 'three', 'four'])
+
+        # Run / Assert
+        message = ("The data must be numerical if order_by is 'numerical_value'.")
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._order_categories(arr)
+
+    def test__order_categories_numerical_different_dtype_error(self):
+        """Test the ``_order_categories`` method when ``order_by`` is 'numerical_value'.
+
+        If the array is made up of a dtype that is not numeric and can't be converted to a float,
+        and `order_by` is 'numerical_value', then we should raise an error.
+        Setup:
+            - Set ``order_by`` to 'numerical_value'.
+        Input:
+            - numpy array of booleans.
+        Expected behavior:
+            - Error should be raised.
+        """
+        # Setup
+        transformer = UniformEncoder(order_by='numerical_value')
+        arr = np.array([True, False, False, True])
+
+        # Run / Assert
+        message = ("The data must be numerical if order_by is 'numerical_value'.")
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._order_categories(arr)
+
+    def test__fit(self):
+        """Test the ``_fit`` method.
+
+        Check the frequencies and intervals dictionnary.
+        """
+        # Setup
+        transformer = UniformEncoder()
+
+        # Run
+        data = pd.Series(['foo', 'bar', 'bar', 'foo', 'foo', 'tar'])
+        transformer._fit(data)
+
+        # Asserts
+        expected_frequencies = {
+            'foo': 0.5,
+            'bar': 0.3333333333333333,
+            'tar': 0.16666666666666666
+        }
+        expected_intervals = {
+            'foo': [0., 0.5],
+            'bar': [0.5, 0.8333333333333333],
+            'tar': [0.8333333333333333, 1.0]
+        }
+        assert transformer.frequencies == expected_frequencies
+        assert transformer.intervals == expected_intervals
+
+    def test__transform(self):
+        """Test the ``_transform`` method.
+
+        Check that the labels are correctly mapped
+        according to their interval.
+        """
+        # Setup
+        transformer = UniformEncoder()
+        data = pd.Series(['foo', 'bar', 'bar', 'foo', 'foo', 'tar'])
+        transformer.frequencies = {
+            'foo': 0.5,
+            'bar': 0.3333333333333333,
+            'tar': 0.16666666666666666
+        }
+        transformer.intervals = {
+            'foo': [0., 0.5],
+            'bar': [0.5, 0.8333333333333333],
+            'tar': [0.8333333333333333, 1.0]
+        }
+
+        # Run
+        transformed = transformer._transform(data)
+
+        # Asserts
+        for key in transformer.intervals:
+            assert (transformed.loc[data == key] >= transformer.intervals[key][0]).all()
+            assert (transformed.loc[data == key] < transformer.intervals[key][1]).all()
+
+    def test__transform_user_warning(self):
+        """Test the ``transform`` with unknown data.
+
+        In this test ``transform`` should raise a warning due to the attempt
+        of transforming data with previously unseen categories.
+
+        Input:
+        - Series with unknown categorical values
+        """
+        # Setup
+        data = pd.DataFrame({'col': [1, 2, 3, 4]})
+        data_1 = data['col'].copy()
+        data_1.loc[4] = 5
+        data_2 = pd.Series([1, 2, 3, 4, 5, 'a', 7, 8, 'b'])
+        transformer = UniformEncoder()
+        transformer.columns = ['col']
+        transformer.frequencies = {
+            1: 0.25, 2: 0.25, 3: 0.25, 4: 0.25
+        }
+
+        transformer.intervals = {
+            1: [0, 0.25],
+            2: [0.25, 0.5],
+            3: [0.5, 0.75],
+            4: [0.75, 1]
+        }
+
+        # Run
+        warning_msg_1 = re.escape(
+            "The data in column 'col' contains new categories"
+            " that did not appear during 'fit' (5). Assigning"
+            ' them random values. If you want to model new categories,'
+            " please fit the data again using 'fit'."
+        )
+
+        warning_msg_2 = re.escape(
+            "The data in column 'col' contains new categories"
+            " that did not appear during 'fit' (5, a, 7, +2 more). Assigning"
+            ' them random values. If you want to model new categories,'
+            " please fit the data again using 'fit'."
+        )
+
+        # Assert
+        with pytest.warns(UserWarning, match=warning_msg_1):
+            transformed = transformer._transform(data_1)
+        with pytest.warns(UserWarning, match=warning_msg_2):
+            transformed = transformer._transform(data_2)
+
+        assert transformed.iloc[4] >= 0
+        assert transformed.iloc[4] < 1
+
+    def test__reverse_transform(self):
+        """Test the ``_reverse_transform``."""
+        # Setup
+        data = pd.Series([1, 2, 3, 2, 2, 1, 3, 3, 2])
+        transformer = UniformEncoder()
+        transformer.dtype = np.int64
+        transformer.frequencies = {
+            1: 0.222222,
+            2: 0.444444,
+            3: 0.333333
+        }
+        transformer.intervals = {
+            1: [0, 0.222222],
+            2: [0.222222, 0.666666],
+            3: [0.666666, 1.0]
+        }
+
+        transformed = pd.Series([0.12, 0.254, 0.789, 0.43, 0.56, 0.08, 0.67, 0.98, 0.36])
+
+        # Run
+        output = transformer._reverse_transform(transformed)
+
+        # Asserts
+        pd.testing.assert_series_equal(output, data)
+
+    def test__reverse_transform_nans(self):
+        """Test ``_reverse_transform`` for data with NaNs."""
+        # Setup
+        data = pd.Series(['a', 'b', 'c', np.nan, 'c', 'b', 'b', 'a', 'b', np.nan])
+        transformer = UniformEncoder()
+        transformer.dtype = object
+        transformer.frequencies = {
+            'a': 0.2,
+            'b': 0.4,
+            'c': 0.2,
+            np.nan: 0.2
+        }
+        transformer.intervals = {
+            'a': [0, 0.2],
+            'b': [0.2, 0.6],
+            'c': [0.6, 0.8],
+            np.nan: [0.8, 1]
+        }
+
+        transformed = pd.Series([0.12, 0.254, 0.789, 0.88, 0.69, 0.53, 0.47, 0.08, 0.39, 0.92])
+
+        # Run
+        output = transformer._reverse_transform(transformed)
+
+        # Asserts
+        pd.testing.assert_series_equal(output, data)
+
+
+@pytest.fixture(autouse=True)
+def _setup_caplog(caplog):
+    """Define the logging for info message."""
+    caplog.set_level(logging.INFO)
+
+
+class TestOrderedUniformEncoder:
+    """Unit test for the ``OrderedUniformEncoder``."""
+
+    def test___init__(self):
+        """The the ``__init__`` method.
+
+        Passed arguments must be stored as attributes.
+        """
+        # Run
+        transformer = OrderedUniformEncoder(order=['b', 'c', 'a', None])
+
+        # Asserts
+        pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
+
+    def test___repr___default(self):
+        """Test that the ``__repr__`` method prints the custom order.
+
+        The order should be printed as <CUSTOM> instead of the actual order.
+        """
+        # Setup
+        transformer = OrderedUniformEncoder(order=['VISA', 'AMEX', 'DISCOVER', None])
+
+        # Run
+        stringified_transformer = transformer.__repr__()
+
+        # Assert
+        assert stringified_transformer == 'OrderedUniformEncoder(order=<CUSTOM>)'
+
+    def test__fit(self):
+        """Test the ``_fit`` method.
+
+        Validate that a unique integer representation for each category of the data is stored
+        in the ``categories_to_values`` attribute, and the reverse is stored in the
+        ``values_to_categories`` attribute. The order should match the ``self.order`` indices.
+        Setup:
+            - create an instance of the ``CustomLabelEncoder``.
+        Input:
+            - a pandas series.
+        Side effects:
+            - set the ``values_to_categories`` dictionary to the appropriate value.
+            - set ``categories_to_values`` dictionary to the appropriate value.
+        """
+        # Setup
+        data = pd.Series([1, 2, 3, 2, np.nan, 1, 1])
+        transformer = OrderedUniformEncoder(order=[2, 3, np.nan, 1])
+
+        # Run
+        transformer._fit(data)
+
+        # Assert
+        expected_frequencies = {
+            2: 0.2857142857142857,
+            3: 0.14285714285714285,
+            None: 0.14285714285714285,
+            1: 0.42857142857142855
+        }
+        expected_intervals = {
+            2: [0.0, 0.2857142857142857],
+            3: [0.2857142857142857, 0.42857142857142855],
+            None: [0.42857142857142855, 0.5714285714285714],
+            1: [0.5714285714285714, 1.0]
+        }
+        assert transformer.frequencies == expected_frequencies
+        assert transformer.intervals == expected_intervals
+
+    def test__fit_error(self):
+        """Test the ``_fit`` method checks that data is in ``self.order``.
+
+        If the data being fit is not in ``self.order`` an error should be raised.
+        """
+        # Setup
+        data = pd.Series([1, 2, 3, 2, 1, 4])
+        transformer = OrderedUniformEncoder(order=[2, 1])
+
+        # Run / Assert
+        message = re.escape(
+            "Unknown categories '[3, 4]'. All possible categories must be defined in the "
+            "'order' parameter."
+        )
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._fit(data)
+
+    def test__fit_info(self, caplog):
+        """Test the ``_fit`` method checks that data is in ``self.order``.
+
+        If the data being fit does not contain all the category of ``self.order``,
+        an info message should be raised.
+        """
+        # Setup
+        data = pd.DataFrame({'column_name': [1, 2, 1, 1, 2, 3, 1, 2]})
+        transformer = OrderedUniformEncoder(order=[1, 2, 3, 4, 5, 6, 7])
+
+        # Run
+        transformer.fit(data, 'column_name')
+        expected_message = (
+            "For column 'column_name', some of the provided category "
+            'values were not present in the data during fit: (4, 5, 6, +1 more).'
+        )
+
+        # Assert
+        assert expected_message in caplog.text
+
+    def test__fit_info_nan(self, caplog):
+        """Test the ``_fit`` method checks that data is in ``self.order``.
+
+        If the data being fit does not contain all the category of ``self.order``,
+        an info should be raised. Check if it works for NaNs.
+        """
+        # Setup
+        data = pd.DataFrame({'column_name': [1, 2, 1, 1, 2, 3, 1, 2]})
+        transformer = OrderedUniformEncoder(order=[1, 2, 3, np.nan])
+
+        # Run
+        transformer.fit(data, 'column_name')
+        expected_message = (
+            "For column 'column_name', some of the provided category "
+            'values were not present in the data during fit: (None).'
+        )
+
+        # Assert
+        assert expected_message in caplog.text
+
+    def test__transform_error(self):
+        """Test the ``_transform`` method checks that data is in ``self.order``.
+
+        If the data being transformed is not in ``self.order`` an error should be raised.
+        """
+        # Setup
+        data = pd.Series([1, 2, 3, 2, 1, 4])
+        transformer = OrderedUniformEncoder(order=[2, 1])
+
+        # Run / Assert
+        message = re.escape(
+            "Unknown categories '[3, 4]'. All possible categories must be defined in the "
+            "'order' parameter."
+        )
+        with pytest.raises(TransformerInputError, match=message):
+            transformer._transform(data)
 
 
 class TestFrequencyEncoder:


### PR DESCRIPTION
Resolve #678
Compared to the other version, a few changes were necessary in order to get 100% coverage and make the minimum version works.
In this PR, the `UniformEncoder` is set to be the default transformer for `categorical` and `boolean` data.