### PR TITLE
Deprecate get_input_sdtype

### DIFF
--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -145,7 +145,7 @@ def get_transformers_by_type():
     sdtype_transformers = defaultdict(list)
     transformer_classes = BaseTransformer.get_subclasses()
     for transformer in transformer_classes:
-        input_sdtype = transformer.get_input_sdtype()
+        input_sdtype = transformer.get_supported_sdtypes()[0]
         sdtype_transformers[input_sdtype].append(transformer)
 
     return sdtype_transformers

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -185,7 +185,7 @@ class BaseTransformer:
                 Accepted input sdtype of the transformer.
         """
         warnings.warn(
-            '``get_input_sdtype`` is deprecated. Please use ``get_supported_sdtypes`` instead.',
+            '`get_input_sdtype` is deprecated. Please use `get_supported_sdtypes` instead.',
             FutureWarning
         )
         return cls.get_supported_sdtypes()[0]

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -188,7 +188,7 @@ class BaseTransformer:
             '``get_input_sdtype`` is deprecated. Please use ``get_supported_sdtypes`` instead.',
             FutureWarning
         )
-        return cls.get_supported_sdtypes()
+        return cls.get_supported_sdtypes()[0]
 
     @classmethod
     def get_supported_sdtypes(cls):

--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -184,7 +184,11 @@ class BaseTransformer:
             string:
                 Accepted input sdtype of the transformer.
         """
-        return cls.INPUT_SDTYPE
+        warnings.warn(
+            '``get_input_sdtype`` is deprecated. Please use ``get_supported_sdtypes`` instead.',
+            FutureWarning
+        )
+        return cls.get_supported_sdtypes()
 
     @classmethod
     def get_supported_sdtypes(cls):

--- a/tests/contributing.py
+++ b/tests/contributing.py
@@ -365,7 +365,7 @@ def validate_transformer_performance(transformer):
 
     print(f'Validating Performance for transformer {transformer.get_name()}\n')
 
-    sdtype = transformer.get_input_sdtype()
+    sdtype = transformer.get_supported_sdtypes()[0]
     transformers = get_transformers_by_type().get(sdtype, [])
     dataset_generators = get_dataset_generators_by_type().get(sdtype, [])
 

--- a/tests/integration/test_transformers.py
+++ b/tests/integration/test_transformers.py
@@ -130,7 +130,7 @@ def _validate_reverse_transformed_data(transformer, reversed_data, input_dtype):
 
     Expect that the dtype is equal to the dtype of the input data.
     """
-    expected_sdtype = transformer.get_input_sdtype()
+    expected_sdtype = transformer.get_supported_sdtypes()[0]
     message = f'Reverse transformed data is not the expected sdtype {expected_sdtype}'
     assert reversed_data.dtypes[TEST_COL].kind in SDTYPE_TO_DTYPES[expected_sdtype], message
 
@@ -181,7 +181,7 @@ def _validate_hypertransformer_transformed_data(transformed_data):
 
 def _validate_hypertransformer_reverse_transformed_data(transformer, reversed_data):
     """Check that the reverse transformed data has the same dtype as the input."""
-    expected_sdtype = transformer().get_input_sdtype()
+    expected_sdtype = transformer().get_supported_sdtypes()[0]
     message = f'Reversed transformed data is not the expected sdtype {expected_sdtype}'
     assert reversed_data.dtype.kind in SDTYPE_TO_DTYPES[expected_sdtype], message
 
@@ -250,7 +250,7 @@ def validate_transformer(transformer, steps=None, subtests=None):
         subtests:
             Whether or not to test with subtests.
     """
-    input_sdtype = transformer.get_input_sdtype()
+    input_sdtype = transformer.get_supported_sdtypes()[0]
 
     dataset_generators = _find_dataset_generators(input_sdtype, generators)
     _validate_helper(_validate_dataset_generators, [dataset_generators], steps)

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -2246,11 +2246,10 @@ class TestHyperTransformer(TestCase):
         instance = HyperTransformer()
         instance._fitted = False
         mock_transformer = Mock()
-        mock_transformer.get_supported_sdtypes.return_value = ['datetime']
         column_name_to_transformer = {
             'my_column': mock_transformer
         }
-
+        expected_config = instance.get_config()
         # Run
         expected_msg = (
             'Nothing to update. Use the `detect_initial_config` method to pre-populate '
@@ -2258,6 +2257,8 @@ class TestHyperTransformer(TestCase):
         )
         with pytest.raises(ConfigNotSetError, match=expected_msg):
             instance.update_transformers(column_name_to_transformer)
+
+        assert instance.get_config() == expected_config
 
     @patch('rdt.hyper_transformer.print')
     def test_update_transformers_missmatch_sdtypes(self, mock_warnings):

--- a/tests/unit/test_hyper_transformer.py
+++ b/tests/unit/test_hyper_transformer.py
@@ -2246,7 +2246,7 @@ class TestHyperTransformer(TestCase):
         instance = HyperTransformer()
         instance._fitted = False
         mock_transformer = Mock()
-        mock_transformer.get_supported_sdtype.return_value = ['datetime']
+        mock_transformer.get_supported_sdtypes.return_value = ['datetime']
         column_name_to_transformer = {
             'my_column': mock_transformer
         }

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -155,21 +155,14 @@ class TestBaseTransformer:
         assert Child in subclasses
         assert Parent not in subclasses
 
-    def test_get_input_sdtype_raises_warning(self):
+    @patch('rdt.transformers.base.BaseTransformer.get_supported_sdtypes')
+    def test_get_input_sdtype_raises_warning(self, mock_get_supported_sdtypes):
         """Test the ``get_input_sdtype`` method.
 
         This method should raise a FutureWarning and then call ``get_supported_sdtypes_`` method.
-
-        Setup:
-            - create a ``Dummy`` class which inherits from the ``BaseTransformer``,
-            containing only a ``INPUT_SDTYPE`` attribute.
-
-        Output:
-            - the string stored in the ``INPUT_SDTYPE`` attribute.
         """
         # Setup
-        class Dummy(BaseTransformer):
-            INPUT_SDTYPE = 'categorical'
+        mock_get_supported_sdtypes.return_value = ['categorical']
 
         # Run
         expected_message = (
@@ -177,10 +170,11 @@ class TestBaseTransformer:
             '``get_supported_sdtypes`` instead.'
         )
         with pytest.warns(FutureWarning, match=expected_message):
-            input_sdtype = Dummy.get_input_sdtype()
+            input_sdtype = BaseTransformer.get_input_sdtype()
 
         # Assert
         assert input_sdtype == 'categorical'
+        mock_get_supported_sdtypes.assert_called_once()
 
     def test_get_supported_sdtypes_supported_sdtypes(self):
         """Test the ``get_supported_sdtypes`` method.

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -155,10 +155,10 @@ class TestBaseTransformer:
         assert Child in subclasses
         assert Parent not in subclasses
 
-    def test_get_input_sdtype(self):
+    def test_get_input_sdtype_raises_warning(self):
         """Test the ``get_input_sdtype`` method.
 
-        This method should return the value defined in the ``INPUT_SDTYPE`` of the child classes.
+        This method should raise a FutureWarning and then call ``get_supported_sdtypes_`` method.
 
         Setup:
             - create a ``Dummy`` class which inherits from the ``BaseTransformer``,
@@ -172,7 +172,12 @@ class TestBaseTransformer:
             INPUT_SDTYPE = 'categorical'
 
         # Run
-        input_sdtype = Dummy.get_input_sdtype()
+        expected_message = (
+            '``get_input_sdtype`` is deprecated. Please use '
+            '``get_supported_sdtypes`` instead.'
+        )
+        with pytest.warns(FutureWarning, match=expected_message):
+            input_sdtype = Dummy.get_input_sdtype()[0]
 
         # Assert
         assert input_sdtype == 'categorical'

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -177,7 +177,7 @@ class TestBaseTransformer:
             '``get_supported_sdtypes`` instead.'
         )
         with pytest.warns(FutureWarning, match=expected_message):
-            input_sdtype = Dummy.get_input_sdtype()[0]
+            input_sdtype = Dummy.get_input_sdtype()
 
         # Assert
         assert input_sdtype == 'categorical'

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -166,8 +166,8 @@ class TestBaseTransformer:
 
         # Run
         expected_message = (
-            '``get_input_sdtype`` is deprecated. Please use '
-            '``get_supported_sdtypes`` instead.'
+            '`get_input_sdtype` is deprecated. Please use '
+            '`get_supported_sdtypes` instead.'
         )
         with pytest.warns(FutureWarning, match=expected_message):
             input_sdtype = BaseTransformer.get_input_sdtype()


### PR DESCRIPTION
Resolve #682
I supposed that every call of `get_input_sdtype()` could be changed by `get_supported_sdtypes()[0]`, is it fine?