### PR TITLE
When no rounding scheme is detected, log the info instead of showing a warning

### DIFF
--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -1,5 +1,6 @@
 """Transformers for numerical data."""
 import copy
+import logging
 import sys
 import warnings
 
@@ -10,6 +11,8 @@ from sklearn.mixture import BayesianGaussianMixture
 
 from rdt.transformers.base import BaseTransformer
 from rdt.transformers.null import NullTransformer
+
+LOGGER = logging.getLogger(__name__)
 
 EPSILON = np.finfo(np.float32).eps
 MAX_DECIMALS = sys.float_info.dig - 1
@@ -109,8 +112,7 @@ class FloatFormatter(BaseTransformer):
                     return decimal
 
         # Can't round, not equal after MAX_DECIMALS digits of precision
-        warnings.warn(
-            f"No rounding scheme detected for column '{name}'. Data will not be rounded.")
+        LOGGER.info(f"No rounding scheme detected for column '{name}'. Data will not be rounded.")
         return None
 
     def _raise_out_of_bounds_error(self, value, name, bound_type, min_bound, max_bound):

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -112,7 +112,7 @@ class FloatFormatter(BaseTransformer):
                     return decimal
 
         # Can't round, not equal after MAX_DECIMALS digits of precision
-        LOGGER.info(f"No rounding scheme detected for column '{name}'. Data will not be rounded.")
+        LOGGER.info("No rounding scheme detected for column '%s'. Data will not be rounded.", name)
         return None
 
     def _raise_out_of_bounds_error(self, value, name, bound_type, min_bound, max_bound):

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -24,7 +24,8 @@ class TestFloatFormatter(TestCase):
         assert nt.missing_value_replacement == 'mode'
         assert nt.missing_value_generation == 'random'
 
-    def test__learn_rounding_digits_more_than_15_decimals(self):
+    @patch('rdt.transformers.numerical.LOGGER')
+    def test__learn_rounding_digits_more_than_15_decimals(self, logger_mock):
         """Test the _learn_rounding_digits method with more than 15 decimals.
 
         If the data has more than 15 decimals, return None and raise warning.
@@ -32,11 +33,12 @@ class TestFloatFormatter(TestCase):
         # Setup
         data = pd.Series(np.random.random(size=10).round(20), name='col')
 
-        # Run and Assert
-        warn_msg = "No rounding scheme detected for column 'col'. Data will not be rounded."
-        with pytest.warns(UserWarning, match=warn_msg):
-            output = FloatFormatter._learn_rounding_digits(data)
+        # Run
+        output = FloatFormatter._learn_rounding_digits(data)
 
+        # Assert
+        logger_msg = "No rounding scheme detected for column 'col'. Data will not be rounded."
+        logger_mock.info.assert_called_once_with(logger_msg)
         assert output is None
 
     def test__learn_rounding_digits_less_than_15_decimals(self):

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -37,8 +37,8 @@ class TestFloatFormatter(TestCase):
         output = FloatFormatter._learn_rounding_digits(data)
 
         # Assert
-        logger_msg = "No rounding scheme detected for column 'col'. Data will not be rounded."
-        logger_mock.info.assert_called_once_with(logger_msg)
+        logger_msg = "No rounding scheme detected for column '%s'. Data will not be rounded."
+        logger_mock.info.assert_called_once_with(logger_msg, 'col')
         assert output is None
 
     def test__learn_rounding_digits_less_than_15_decimals(self):


### PR DESCRIPTION
Resolve #709 