### PR TITLE
Add include_lowest so that the first interval should be left inclusive

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -191,7 +191,7 @@ class UniformEncoder(BaseTransformer):
             else:
                 labels.append(key)
 
-        result = pd.cut(data, bins=bins, labels=labels)
+        result = pd.cut(data, bins=bins, labels=labels, include_lowest=True)
         return result.replace(nan_name, np.nan).astype(self.dtype)
 
 

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -75,7 +75,7 @@ class TestUniformEncoder:
         # Asserts
         # Make sure there is no Nan values due to the negative number
         for col in pd.isna(output).any():
-            assert (col == False)
+            assert (not col)
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -70,10 +70,11 @@ class TestUniformEncoder:
         transformer.fit(data, column)
         transformed = transformer.transform(data)
         transformed.loc[1, 'column_name'] = -0.1
+        transformed.loc[2, 'column_name'] = 100
         output = transformer.reverse_transform(transformed)
 
         # Asserts
-        # Make sure there is no Nan values due to the negative number
+        # Make sure there is no Nan values due to the negative number or large upper bound number
         assert all(~pd.isna(output).any())
 
     def test__reverse_transform_nans(self):

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -47,9 +47,8 @@ class TestUniformEncoder:
     def test__reverse_transform(self):
         """Test the ``reverse_transform``."""
         # Setup
-        data = pd.DataFrame({'column_name': [-1, 0, 1, 2, 3, 2, 2, 1, 3, 3, 2, -11, 0]})
+        data = pd.DataFrame({'column_name': [1, 2, 3, 2, 2, 1, 3, 3, 2]})
         column = 'column_name'
-
         transformer = UniformEncoder()
 
         # Run
@@ -59,6 +58,24 @@ class TestUniformEncoder:
 
         # Asserts
         pd.testing.assert_series_equal(output['column_name'], data['column_name'])
+    
+    def test__reverse_transform_negative_transformed_values(self):
+        """Test the ``reverse_transform``."""
+        # Setup
+        data = pd.DataFrame({'column_name': [1, 2, 3, 2, 2, 1, 3, 3, 2]})
+        column = 'column_name'
+        transformer = UniformEncoder()
+
+        # Run
+        transformer.fit(data, column)
+        transformed = transformer.transform(data)
+        transformed.loc[1,'column_name'] = -0.1
+        output = transformer.reverse_transform(transformed)
+
+        # Asserts
+        # Make sure there is no Nan values due to the negative number
+        for col in pd.isna(output).any():
+            assert(col == False)
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -58,7 +58,7 @@ class TestUniformEncoder:
 
         # Asserts
         pd.testing.assert_series_equal(output['column_name'], data['column_name'])
-    
+
     def test__reverse_transform_negative_transformed_values(self):
         """Test the ``reverse_transform``."""
         # Setup
@@ -69,13 +69,13 @@ class TestUniformEncoder:
         # Run
         transformer.fit(data, column)
         transformed = transformer.transform(data)
-        transformed.loc[1,'column_name'] = -0.1
+        transformed.loc[1, 'column_name'] = -0.1
         output = transformer.reverse_transform(transformed)
 
         # Asserts
         # Make sure there is no Nan values due to the negative number
         for col in pd.isna(output).any():
-            assert(col == False)
+            assert (col == False)
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -47,7 +47,7 @@ class TestUniformEncoder:
     def test__reverse_transform(self):
         """Test the ``reverse_transform``."""
         # Setup
-        data = pd.DataFrame({'column_name': [1, 2, 3, 2, 2, 1, 3, 3, 2]})
+        data = pd.DataFrame({'column_name': [-1, 0, 1, 2, 3, 2, 2, 1, 3, 3, 2, -11, 0]})
         column = 'column_name'
 
         transformer = UniformEncoder()

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -74,8 +74,7 @@ class TestUniformEncoder:
 
         # Asserts
         # Make sure there is no Nan values due to the negative number
-        for col in pd.isna(output).any():
-            assert (not col)
+        assert all(~pd.isna(output).any())
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""


### PR DESCRIPTION
resolves #719 

This prevents lower values from being converted to Nans which contributed to the issue seen where transformed categorical data had NaNs despite original data not containing and NaNs