### PR TITLE
Remove unnecessary `OneHotEncoder` when there are nan values

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -634,7 +634,7 @@ class OneHotEncoder(BaseTransformer):
         """
         data = self._prepare_data(data)
         unique_data = {np.nan if pd.isna(x) else x for x in pd.unique(data)}
-        unseen_categories = unique_data - set(self.dummies)
+        unseen_categories = unique_data - {np.nan if pd.isna(x) else x for x in self.dummies}
         if unseen_categories:
             # Select only the first 5 unseen categories to avoid flooding the console.
             examples_unseen_categories = set(list(unseen_categories)[:5])

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -1,5 +1,4 @@
 import pickle
-import tempfile
 import warnings
 from io import BytesIO
 
@@ -426,7 +425,7 @@ def test_one_hot_numerical_nans():
     pd.testing.assert_frame_equal(reverse, data)
 
 
-def test_one_hot_doesnt_warn():
+def test_one_hot_doesnt_warn(tmp_path):
     """Ensure OneHotEncoder doesn't warn when saving and loading GH#616."""
     # Setup
     data = pd.DataFrame({'column_name': [1.0, 2.0, np.nan, 2.0, 3.0, np.nan, 3.0]})
@@ -434,11 +433,11 @@ def test_one_hot_doesnt_warn():
 
     # Run
     ohe.fit(data, 'column_name')
-    # Create a temporary file and dump the transformer
-    tmp = tempfile.NamedTemporaryFile()
-    pickle.dump(ohe, tmp)
-    tmp.seek(0)
-    ohe_loaded = pickle.load(tmp)
+    tmp = tmp_path / 'ohe.pkl'
+    with open(tmp, 'wb') as tmp:
+        pickle.dump(ohe, tmp)
+    with open(tmp.name, 'rb') as tmp:
+        ohe_loaded = pickle.load(tmp)
 
     # Assert
     with warnings.catch_warnings():

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -434,10 +434,10 @@ def test_one_hot_doesnt_warn(tmp_path):
     # Run
     ohe.fit(data, 'column_name')
     tmp = tmp_path / 'ohe.pkl'
-    with open(tmp, 'wb') as tmp:
-        pickle.dump(ohe, tmp)
-    with open(tmp.name, 'rb') as tmp:
-        ohe_loaded = pickle.load(tmp)
+    with open(tmp, 'wb') as f:
+        pickle.dump(ohe, f)
+    with open(tmp.name, 'rb') as f:
+        ohe_loaded = pickle.load(f)
 
     # Assert
     with warnings.catch_warnings():

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -434,15 +434,16 @@ def test_one_hot_doesnt_warn():
 
     # Run
     ohe.fit(data, 'column_name')
-    with tempfile.NamedTemporaryFile() as tmp:
-        pickle.dump(ohe, tmp)
-        with open(tmp.name, 'rb') as f:
-            ht_loaded = pickle.load(f)
+    # Create a temporary file and dump the transformer
+    tmp = tempfile.NamedTemporaryFile()
+    pickle.dump(ohe, tmp)
+    tmp.seek(0)
+    ohe_loaded = pickle.load(tmp)
 
     # Assert
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        ht_loaded.transform(data)
+        ohe_loaded.transform(data)
 
 
 def test_label_numerical_2d_array():

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -434,7 +434,7 @@ def test_one_hot_doesnt_warn(tmp_path):
     # Run
     ohe.fit(data, 'column_name')
     tmp = tmp_path / 'ohe.pkl'
-    with open(tmp, 'wb') as f:
+    with open(tmp.name, 'wb') as f:
         pickle.dump(ohe, f)
     with open(tmp.name, 'rb') as f:
         ohe_loaded = pickle.load(f)


### PR DESCRIPTION
Resolve #616.