### PR TITLE
Add include_lowest so that the first interval should be left inclusive

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -191,7 +191,7 @@ class UniformEncoder(BaseTransformer):
             else:
                 labels.append(key)
 
-        result = pd.cut(data, bins=bins, labels=labels)
+        result = pd.cut(data, bins=bins, labels=labels, include_lowest=True)
         return result.replace(nan_name, np.nan).astype(self.dtype)
 
 

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -76,7 +76,7 @@ class TestUniformEncoder:
 
         # Asserts
         # Make sure there is no Nan values due to the negative number or large upper bound number
-        assert not any(pd.isna(output).values)
+        assert not any(pd.isna(output).to_numpy())
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -76,7 +76,7 @@ class TestUniformEncoder:
 
         # Asserts
         # Make sure there is no Nan values due to the negative number or large upper bound number
-        assert all(~pd.isna(output).any())
+        assert not any(pd.isna(output).values)
 
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""

--- a/tests/integration/transformers/test_categorical.py
+++ b/tests/integration/transformers/test_categorical.py
@@ -60,6 +60,24 @@ class TestUniformEncoder:
         # Asserts
         pd.testing.assert_series_equal(output['column_name'], data['column_name'])
 
+    def test__reverse_transform_negative_transformed_values(self):
+        """Test the ``reverse_transform``."""
+        # Setup
+        data = pd.DataFrame({'column_name': [1, 2, 3, 2, 2, 1, 3, 3, 2]})
+        column = 'column_name'
+        transformer = UniformEncoder()
+
+        # Run
+        transformer.fit(data, column)
+        transformed = transformer.transform(data)
+        transformed.loc[1, 'column_name'] = -0.1
+        transformed.loc[2, 'column_name'] = 100
+        output = transformer.reverse_transform(transformed)
+
+        # Asserts
+        # Make sure there is no Nan values due to the negative number or large upper bound number
+        assert all(~pd.isna(output).any())
+
     def test__reverse_transform_nans(self):
         """Test ``reverse_transform`` for data with NaNs."""
         # Setup


### PR DESCRIPTION
resolves https://github.com/sdv-dev/RDT/issues/719

This prevents lower values from being converted to Nans which contributed to the issue seen where transformed categorical data had NaNs despite original data not containing and NaNs