### PR TITLE
 Resolve warning when applying the `'en_US'` locale myself

### DIFF
--- a/rdt/transformers/pii/anonymizer.py
+++ b/rdt/transformers/pii/anonymizer.py
@@ -85,7 +85,7 @@ class AnonymizedFaker(BaseTransformer):
                 provider_name = self.provider_name.replace(f'.{locale}', '')
 
             spec = importlib.util.find_spec(f'faker.providers.{provider_name}.{locale}')
-            if spec is None:
+            if spec is None and locale != 'en_US':
                 missed_locales.append(locale)
 
         if missed_locales:


### PR DESCRIPTION
CU-86ayjz2p8
Resolve sdv-dev/SDV#1652

I changed the warning logic to prevent warning for `'en_US'`, but it seems like the actual problem was solved by updating Faker since I can no longer replicate the issue. 