### PR TITLE
Support for columns contains only numbers.

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -304,7 +304,7 @@ class BaseTransformer:
         return data
 
     def _build_output_columns(self, data):
-        self.column_prefix = '#'.join(self.columns)
+        self.column_prefix = '#'.join(map(str, self.columns))
         self.output_columns = self.get_output_columns()
 
         # make sure none of the generated `output_columns` exists in the data,
@@ -362,7 +362,7 @@ class BaseTransformer:
         raise NotImplementedError()
 
     def _set_seed(self, data):
-        hash_value = self.columns[0]
+        hash_value = str(self.columns[0])
         for value in data.head(5):
             hash_value += str(value)
 


### PR DESCRIPTION
In the case where the column names contain only numbers, typically when scaling the data, the code doesn't work well because the first value of the variable will be a numeric value, not a string, to which you cannot append a string later.

The executed commands are:

synthesizer = SingleTablePreset(
    metadata,
    name='FAST_ML'
)

synthesizer.fit(
    data=test_df
)

synthetic_data = synthesizer.sample(
    num_rows=500
)

synthetic_data.head()

The output:

`File [~/GitHub/ml_network_analysis_experiments/.venv/lib/python3.9/site-packages/rdt/transformers/base.py:367](https://file+.vscode-resource.vscode-cdn.net/Users/**********/GitHub/ml_network_analysis_experiments/~/GitHub/ml_network_analysis_experiments/.venv/lib/python3.9/site-packages/rdt/transformers/base.py:367), in BaseTransformer._set_seed(self, data)
    365 hash_value = self.columns[0]
    366 for value in data.head(5):
--> 367     hash_value += str(value)
    369 hash_value = int(hashlib.sha256(hash_value.encode('utf-8')).hexdigest(), 16)
    370 self.random_seed = hash_value % ((2 ** 32) - 1)  # maximum value for a seed`

This is why this modifications are needed.  

`self.column_prefix = '#'.join(map(str, self.columns))`

and 

`hash_value = str(self.columns[0])`

