### PR TITLE
Categorical reverse transform may crash with `ValueError` for certain dtypes (int64)

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -9,34 +9,9 @@ from scipy.stats import norm
 
 from rdt.errors import TransformerInputError
 from rdt.transformers.base import BaseTransformer
-from rdt.transformers.utils import check_nan_in_transform, fill_nan_with_none
+from rdt.transformers.utils import check_nan_in_transform, fill_nan_with_none, try_convert_to_dtype
 
 LOGGER = logging.getLogger(__name__)
-
-
-def try_convert_to_dtype(data, dtype):
-    """Try to convert data to a given dtype.
-
-    Args:
-        data (pd.Series or numpy.ndarray):
-            Data to convert.
-        dtype (str):
-            Data type to convert to.
-
-    Returns:
-        data:
-            Data converted to the given dtype.
-    """
-    try:
-        data = data.astype(dtype)
-    except ValueError as error:
-        is_integer = pd.api.types.is_integer_dtype(dtype)
-        if is_integer:
-            data = data.astype(float)
-        else:
-            raise error
-
-    return data
 
 
 class UniformEncoder(BaseTransformer):

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -50,7 +50,7 @@ class UniformEncoder(BaseTransformer):
             )
 
         self.order_by = order_by
-        self._is_integer = False
+        self._is_integer = None
 
     def _order_categories(self, unique_data):
         nans = pd.isna(unique_data)
@@ -342,7 +342,7 @@ class FrequencyEncoder(BaseTransformer):
         )
         super().__init__()
         self.add_noise = add_noise
-        self._is_integer = False
+        self._is_integer = None
 
     @staticmethod
     def _get_intervals(data):
@@ -723,7 +723,7 @@ class LabelEncoder(BaseTransformer):
             )
 
         self.order_by = order_by
-        self._is_integer = False
+        self._is_integer = None
 
     def _order_categories(self, unique_data):
         if self.order_by == 'alphabetical':

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -9,9 +9,34 @@ from scipy.stats import norm
 
 from rdt.errors import TransformerInputError
 from rdt.transformers.base import BaseTransformer
-from rdt.transformers.utils import check_nan_in_transform, fill_nan_with_none, try_convert_to_dtype
+from rdt.transformers.utils import check_nan_in_transform, fill_nan_with_none
 
 LOGGER = logging.getLogger(__name__)
+
+
+def try_convert_to_dtype(data, dtype):
+    """Try to convert data to a given dtype.
+
+    Args:
+        data (pd.Series or numpy.ndarray):
+            Data to convert.
+        dtype (str):
+            Data type to convert to.
+
+    Returns:
+        data:
+            Data converted to the given dtype.
+    """
+    try:
+        data = data.astype(dtype)
+    except ValueError as error:
+        is_integer = pd.api.types.is_integer_dtype(dtype)
+        if is_integer:
+            data = data.astype(float)
+        else:
+            raise error
+
+    return data
 
 
 class UniformEncoder(BaseTransformer):

--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -551,6 +551,7 @@ class OneHotEncoder(BaseTransformer):
     _dummy_encoded = False
     _indexer = None
     _uniques = None
+    dtype = None
 
     @staticmethod
     def _prepare_data(data):
@@ -588,6 +589,7 @@ class OneHotEncoder(BaseTransformer):
             data (pandas.Series or pandas.DataFrame):
                 Data to fit the transformer to.
         """
+        self.dtype = data.dtype
         data = self._prepare_data(data)
 
         null = pd.isna(data).to_numpy()
@@ -663,6 +665,7 @@ class OneHotEncoder(BaseTransformer):
         Returns:
             pandas.Series
         """
+        check_nan_in_transform(data, self.dtype)
         if not isinstance(data, np.ndarray):
             data = data.to_numpy()
 
@@ -670,8 +673,10 @@ class OneHotEncoder(BaseTransformer):
             data = data.reshape(-1, 1)
 
         indices = np.argmax(data, axis=1)
+        result = pd.Series(indices).map(self.dummies.__getitem__)
+        result = try_convert_to_dtype(result, self.dtype)
 
-        return pd.Series(indices).map(self.dummies.__getitem__)
+        return result
 
 
 class LabelEncoder(BaseTransformer):

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -2,8 +2,10 @@
 
 import re
 import string
+import warnings
 
 import numpy as np
+import pandas as pd
 
 import sre_parse  # isort:skip
 
@@ -184,3 +186,33 @@ def flatten_column_list(column_list):
             flattened.append(column)
 
     return flattened
+
+
+def check_nan_in_transform(data, is_integer=False):
+    """Check if there are null values in the transformed data.
+
+    Args:
+        data (pd.Series or numpy.ndarray):
+            Data that has been transformed.
+        is_integer (bool):
+            Indicates if the initial data was integer.
+
+    Returns:
+        bool:
+            Indicates if the transformed data has to be converted to float.
+    """
+    convert_to_float = False
+    if pd.isna(data).any():
+        message = (
+            'There are null values in the transformed data. The reversed '
+            'transformed data will contain null values'
+        )
+        if is_integer:
+            message += " of type 'float'."
+            convert_to_float = True
+        else:
+            message += '.'
+
+        warnings.warn(message)
+
+    return convert_to_float

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -197,7 +197,7 @@ def check_nan_in_transform(data, dtype):
         dtype (str):
             Data type of the transformed data.
     """
-    if pd.isna(data).any():
+    if pd.isna(data).any().any():
         message = (
             'There are null values in the transformed data. The reversed '
             'transformed data will contain null values'

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -209,28 +209,3 @@ def check_nan_in_transform(data, dtype):
             message += '.'
 
         warnings.warn(message)
-
-
-def try_convert_to_dtype(data, dtype):
-    """Try to convert data to a given dtype.
-
-    Args:
-        data (pd.Series or numpy.ndarray):
-            Data to convert.
-        dtype (str):
-            Data type to convert to.
-
-    Returns:
-        data:
-            Data converted to the given dtype.
-    """
-    try:
-        data = data.astype(dtype)
-    except ValueError as error:
-        is_integer = pd.api.types.is_integer_dtype(dtype)
-        if is_integer:
-            data = data.astype(float)
-        else:
-            raise error
-
-    return data

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -188,31 +188,49 @@ def flatten_column_list(column_list):
     return flattened
 
 
-def check_nan_in_transform(data, is_integer=False):
+def check_nan_in_transform(data, dtype):
     """Check if there are null values in the transformed data.
 
     Args:
         data (pd.Series or numpy.ndarray):
             Data that has been transformed.
-        is_integer (bool):
-            Indicates if the initial data was integer.
-
-    Returns:
-        bool:
-            Indicates if the transformed data has to be converted to float.
+        dtype (str):
+            Data type of the transformed data.
     """
-    convert_to_float = False
     if pd.isna(data).any():
         message = (
             'There are null values in the transformed data. The reversed '
             'transformed data will contain null values'
         )
+        is_integer = pd.api.types.is_integer_dtype(dtype)
         if is_integer:
             message += " of type 'float'."
-            convert_to_float = True
         else:
             message += '.'
 
         warnings.warn(message)
 
-    return convert_to_float
+
+def try_convert_to_dtype(data, dtype):
+    """Try to convert data to a given dtype.
+
+    Args:
+        data (pd.Series or numpy.ndarray):
+            Data to convert.
+        dtype (str):
+            Data type to convert to.
+
+    Returns:
+        data:
+            Data converted to the given dtype.
+    """
+    try:
+        data = data.astype(dtype)
+    except ValueError as error:
+        is_integer = pd.api.types.is_integer_dtype(dtype)
+        if is_integer:
+            data = data.astype(float)
+        else:
+            raise error
+
+    return data

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -209,3 +209,28 @@ def check_nan_in_transform(data, dtype):
             message += '.'
 
         warnings.warn(message)
+
+
+def try_convert_to_dtype(data, dtype):
+    """Try to convert data to a given dtype.
+
+    Args:
+        data (pd.Series or numpy.ndarray):
+            Data to convert.
+        dtype (str):
+            Data type to convert to.
+
+    Returns:
+        data:
+            Data converted to the given dtype.
+    """
+    try:
+        data = data.astype(dtype)
+    except ValueError as error:
+        is_integer = pd.api.types.is_integer_dtype(dtype)
+        if is_integer:
+            data = data.astype(float)
+        else:
+            raise error
+
+    return data

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -51,6 +51,7 @@ class TestUniformEncoder:
         ordered = transformer._order_categories(arr)
 
         # Assert
+        assert transformer._is_integer is False
         np.testing.assert_array_equal(ordered, np.array(['four', 'one', 'three', 'two']))
 
     def test__order_categories_alphabetical_with_nans(self):
@@ -366,6 +367,7 @@ class TestOrderedUniformEncoder:
         transformer = OrderedUniformEncoder(order=['b', 'c', 'a', None])
 
         # Asserts
+        assert transformer._is_integer is False
         pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
 
     def test___init___duplicate_categories(self):
@@ -558,6 +560,7 @@ class TestFrequencyEncoder:
 
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
+        assert transformer._is_integer is False
 
     def test__get_intervals(self):
         """Test the ``_get_intervals`` method.
@@ -1889,6 +1892,7 @@ class TestLabelEncoder:
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
         assert transformer.order_by == 'alphabetical'
+        assert transformer._is_integer is False
 
     def test___init___bad_order_by(self):
         """Test that the ``__init__`` raises error if ``order_by`` is a bad value.
@@ -2261,6 +2265,7 @@ class TestOrderedLabelEncoder:
 
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
+        assert transformer._is_integer is False
         pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
 
     def test___init___duplicate_categories(self):

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -9,9 +9,30 @@ import pytest
 from rdt.errors import TransformerInputError
 from rdt.transformers.categorical import (
     CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder,
-    OrderedUniformEncoder, UniformEncoder)
+    OrderedUniformEncoder, UniformEncoder, try_convert_to_dtype)
 
 RE_SSN = re.compile(r'\d\d\d-\d\d-\d\d\d\d')
+
+
+def test_try_convert_to_dtype():
+    """Test ``try_convert_to_dtype`` method.
+
+    If the data can be converted to the specified dtype, it should be converted.
+    If the data cannot be converted, a ValueError should be raised.
+    Should allow to convert integer with NaNs to float.
+    """
+    # Setup
+    data_int_with_nan = pd.Series([1.0, 2.0, np.nan, 4.0, 5.0])
+    data_not_convetible = pd.Series(['a', 'b', 'c', 'd', 'e'])
+
+    # Run
+    output_int_with_nan = try_convert_to_dtype(data_int_with_nan, 'int')
+    with pytest.raises(ValueError, match="could not convert string to float: 'a'"):
+        try_convert_to_dtype(data_not_convetible, 'int')
+
+    # Assert
+    expected_data_with_nan = pd.Series([1, 2, np.nan, 4, 5])
+    pd.testing.assert_series_equal(output_int_with_nan, expected_data_with_nan)
 
 
 class TestUniformEncoder:

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -9,30 +9,9 @@ import pytest
 from rdt.errors import TransformerInputError
 from rdt.transformers.categorical import (
     CustomLabelEncoder, FrequencyEncoder, LabelEncoder, OneHotEncoder, OrderedLabelEncoder,
-    OrderedUniformEncoder, UniformEncoder, try_convert_to_dtype)
+    OrderedUniformEncoder, UniformEncoder)
 
 RE_SSN = re.compile(r'\d\d\d-\d\d-\d\d\d\d')
-
-
-def test_try_convert_to_dtype():
-    """Test ``try_convert_to_dtype`` method.
-
-    If the data can be converted to the specified dtype, it should be converted.
-    If the data cannot be converted, a ValueError should be raised.
-    Should allow to convert integer with NaNs to float.
-    """
-    # Setup
-    data_int_with_nan = pd.Series([1.0, 2.0, np.nan, 4.0, 5.0])
-    data_not_convetible = pd.Series(['a', 'b', 'c', 'd', 'e'])
-
-    # Run
-    output_int_with_nan = try_convert_to_dtype(data_int_with_nan, 'int')
-    with pytest.raises(ValueError, match="could not convert string to float: 'a'"):
-        try_convert_to_dtype(data_not_convetible, 'int')
-
-    # Assert
-    expected_data_with_nan = pd.Series([1, 2, np.nan, 4, 5])
-    pd.testing.assert_series_equal(output_int_with_nan, expected_data_with_nan)
 
 
 class TestUniformEncoder:
@@ -2359,6 +2338,7 @@ class TestOrderedLabelEncoder:
         transformer._fit(data)
 
         # Assert
+        assert transformer.dtype == 'float'
         expected_values_to_categories = {0: 2, 1: 3, 2: np.nan, 3: 1}
         expected_categories_to_values = {2: 0, 3: 1, 1: 3, np.nan: 2}
         for key, value in transformer.values_to_categories.items():

--- a/tests/unit/transformers/test_categorical.py
+++ b/tests/unit/transformers/test_categorical.py
@@ -51,7 +51,7 @@ class TestUniformEncoder:
         ordered = transformer._order_categories(arr)
 
         # Assert
-        assert transformer._is_integer is False
+        assert transformer._is_integer is None
         np.testing.assert_array_equal(ordered, np.array(['four', 'one', 'three', 'two']))
 
     def test__order_categories_alphabetical_with_nans(self):
@@ -367,7 +367,7 @@ class TestOrderedUniformEncoder:
         transformer = OrderedUniformEncoder(order=['b', 'c', 'a', None])
 
         # Asserts
-        assert transformer._is_integer is False
+        assert transformer._is_integer is None
         pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
 
     def test___init___duplicate_categories(self):
@@ -560,7 +560,7 @@ class TestFrequencyEncoder:
 
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
-        assert transformer._is_integer is False
+        assert transformer._is_integer is None
 
     def test__get_intervals(self):
         """Test the ``_get_intervals`` method.
@@ -1192,7 +1192,7 @@ class TestFrequencyEncoder:
         mock_input_data = mock_check_nan.call_args.args[0]
         mock_input_boolean = mock_check_nan.call_args.args[1]
         pd.testing.assert_series_equal(mock_input_data, transformed)
-        assert mock_input_boolean is False
+        assert mock_input_boolean is None
         pd.testing.assert_series_equal(data, reverse)
 
 
@@ -1892,7 +1892,7 @@ class TestLabelEncoder:
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
         assert transformer.order_by == 'alphabetical'
-        assert transformer._is_integer is False
+        assert transformer._is_integer is None
 
     def test___init___bad_order_by(self):
         """Test that the ``__init__`` raises error if ``order_by`` is a bad value.
@@ -2232,7 +2232,7 @@ class TestLabelEncoder:
         mock_input_data = mock_check_nan.call_args.args[0]
         mock_input_boolean = mock_check_nan.call_args.args[1]
         pd.testing.assert_series_equal(mock_input_data, data)
-        assert mock_input_boolean is False
+        assert mock_input_boolean is None
 
     def test__reverse_transform_integer_and_nans(self):
         """Test the ``reverse_transform`` method with integers and nans.
@@ -2265,7 +2265,7 @@ class TestOrderedLabelEncoder:
 
         # Asserts
         assert transformer.add_noise == 'add_noise_value'
-        assert transformer._is_integer is False
+        assert transformer._is_integer is None
         pd.testing.assert_series_equal(transformer.order, pd.Series(['b', 'c', 'a', np.nan]))
 
     def test___init___duplicate_categories(self):

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -1,8 +1,9 @@
+import sre_parse
+from sre_constants import MAXREPEAT
+
 import numpy as np
 import pandas as pd
 import pytest
-import sre_parse
-from sre_constants import MAXREPEAT
 
 from rdt.transformers.utils import (
     _any, _max_repeat, check_nan_in_transform, flatten_column_list, strings_from_regex)

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -6,8 +6,7 @@ import pandas as pd
 import pytest
 
 from rdt.transformers.utils import (
-    _any, _max_repeat, check_nan_in_transform, flatten_column_list, strings_from_regex,
-    try_convert_to_dtype)
+    _any, _max_repeat, check_nan_in_transform, flatten_column_list, strings_from_regex)
 
 
 def test_strings_from_regex_literal():
@@ -95,24 +94,3 @@ def test_check_nan_in_transform():
 
     with pytest.warns(UserWarning, match=expected_message_integer):
         check_nan_in_transform(transformed, 'int')
-
-
-def test_try_to_convert_dtype():
-    """Test ``try_convert_to_dtype`` method.
-
-    If the data can be converted to the specified dtype, it should be converted.
-    If the data cannot be converted, a ValueError should be raised.
-    Should allow to convert integer with NaNs to float.
-    """
-    # Setup
-    data_int_with_nan = pd.Series([1.0, 2.0, np.nan, 4.0, 5.0])
-    data_not_convetible = pd.Series(['a', 'b', 'c', 'd', 'e'])
-
-    # Run
-    output_int_with_nan = try_convert_to_dtype(data_int_with_nan, 'int')
-    with pytest.raises(ValueError, match="could not convert string to float: 'a'"):
-        try_convert_to_dtype(data_not_convetible, 'int')
-
-    # Assert
-    expected_data_with_nan = pd.Series([1, 2, np.nan, 4, 5])
-    pd.testing.assert_series_equal(output_int_with_nan, expected_data_with_nan)

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -82,7 +82,10 @@ def test_check_nan_in_transform():
     """
     # Setup
     transformed = pd.Series([0.1026, 0.1651, np.nan, 0.3116, 0.6546, 0.8541, 0.7041])
-    data_without_nans = pd.Series([0.1026, 0.1651, 0.3116, 0.6546, 0.8541, 0.7041])
+    data_without_nans = pd.DataFrame({
+        'col 1': [1, 2, 3],
+        'col 2': [4, 5, 6],
+    })
 
     # Run and Assert
     check_nan_in_transform(data_without_nans, 'float')
@@ -116,8 +119,11 @@ def test_try_convert_to_dtype():
     with pytest.raises(ValueError, match="could not convert string to float: 'a'"):
         try_convert_to_dtype(data_not_convertible, 'int')
 
+    with pytest.raises(ValueError, match="could not convert string to float: 'a'"):
+        try_convert_to_dtype(data_not_convertible, 'float')
+
     # Assert
     expected_data_with_nan = pd.Series([1, 2, np.nan, 4, 5])
-    expected_data_covertibe = pd.Series(['1.0', '2.0', 'nan', '4.0', '5.0'])
+    expected_data_convertibe = pd.Series(['1.0', '2.0', 'nan', '4.0', '5.0'])
     pd.testing.assert_series_equal(output_int_with_nan, expected_data_with_nan)
-    pd.testing.assert_series_equal(output_convertibe, expected_data_covertibe)
+    pd.testing.assert_series_equal(output_convertibe, expected_data_convertibe)


### PR DESCRIPTION
CU-86ayz7xvf
Resolve #747