### PR TITLE
Fix backwards compatability for `cardinality_rule`

### DIFF
--- a/rdt/transformers/pii/anonymizer.py
+++ b/rdt/transformers/pii/anonymizer.py
@@ -177,10 +177,13 @@ class AnonymizedFaker(BaseTransformer):
 
     def _function(self):
         """Return the result of calling the ``faker`` function."""
-        if self.cardinality_rule in {'unique', 'match'}:
-            faker_attr = self.faker.unique
-        else:
-            faker_attr = self.faker
+        try:
+            if self.cardinality_rule in {'unique', 'match'}:
+                faker_attr = self.faker.unique
+            else:
+                faker_attr = self.faker
+        except AttributeError:
+            faker_attr = self.faker.unique if self.enforce_uniqueness else self.faker
 
         result = getattr(faker_attr, self.function_name)(**self.function_kwargs)
 
@@ -262,7 +265,7 @@ class AnonymizedFaker(BaseTransformer):
             sample_size = self.data_length
 
         try:
-            if self.cardinality_rule == 'match':
+            if hasattr(self, 'cardinality_rule') and self.cardinality_rule == 'match':
                 reverse_transformed = self._reverse_transform_cardinality_rule_match(sample_size)
             else:
                 reverse_transformed = np.array([

--- a/tests/integration/transformers/pii/test_anonymizer.py
+++ b/tests/integration/transformers/pii/test_anonymizer.py
@@ -248,6 +248,40 @@ class TestAnonymizedFaker:
         assert len(reverse_transform['col'].unique()) == 3
         assert reverse_transform['col'].isna().sum() == 2
 
+    def test_enforce_uniqueness_backwards_compatability(self):
+        """Test that ``AnonymizedFaker`` is backwards compatible with ``enforce_uniqueness``.
+
+        Checks that transformers without the ``cardinality_rule`` attribute still function as
+        expected (can happen when previous transformer version is loaded from a pkl file).
+        """
+        # Setup
+        data = pd.DataFrame({
+            'job': np.arange(500)
+        })
+
+        instance = AnonymizedFaker('job', 'job', cardinality_rule='match')
+        instance.enforce_uniqueness = True
+
+        transformed = instance.fit_transform(data, 'job')
+        delattr(instance, 'cardinality_rule')
+
+        # Run
+        reverse_transform = instance.reverse_transform(transformed)
+
+        # Assert
+        assert len(reverse_transform['job'].unique()) == 500
+
+        error_msg = re.escape(
+            'The Faker function you specified is not able to generate 500 unique '
+            'values. Please use a different Faker function for column '
+            "('job')."
+        )
+        with pytest.raises(TransformerProcessingError, match=error_msg):
+            instance.reverse_transform(transformed)
+
+        instance.reset_randomization()
+        instance.reverse_transform(transformed)
+
 
 class TestPsuedoAnonymizedFaker:
     def test_default_settings(self):

--- a/tests/unit/transformers/pii/test_anonymizer.py
+++ b/tests/unit/transformers/pii/test_anonymizer.py
@@ -184,6 +184,29 @@ class TestAnonymizedFaker:
         unique_function.assert_called_once_with(type='int')
         assert result == 1
 
+    def test__function_cardinality_rule_missing_attribute(self):
+        """Test it when ``cardinality_rule`` attribute is missing."""
+        # setup
+        instance = Mock()
+        function = Mock()
+        unique_function = Mock()
+        unique_function.return_value = 1
+
+        delattr(instance, 'cardinality_rule')
+        instance.enforce_uniqueness = True
+        instance.faker.unique.number = unique_function
+        instance.faker.number = function
+        instance.function_name = 'number'
+        instance.function_kwargs = {'type': 'int'}
+
+        # Run
+        result = AnonymizedFaker._function(instance)
+
+        # Assert
+        function.assert_not_called()
+        unique_function.assert_called_once_with(type='int')
+        assert result == 1
+
     def test__function_with_iterables_return(self):
         """Test that ``_function`` returns the values of the iterable."""
         # setup
@@ -601,6 +624,20 @@ class TestAnonymizedFaker:
         # Assert
         assert function.call_args_list == [call(), call(), call()]
         assert set(result) == {'a', 'b', 'c'}
+
+    def test__reverse_transform_cardinality_rule_missing_attribute(self):
+        """Test it when the ``cardinality_rule`` attribute is missing."""
+        # Setup
+        instance = Mock()
+        delattr(instance, 'cardinality_rule')
+
+        instance.data_length = 3
+
+        # Run
+        AnonymizedFaker._reverse_transform(instance, None)
+
+        # Assert
+        assert instance._function.call_count == 3
 
     def test__reverse_transform_with_nans(self):
         """Test that ``_reverse_transform`` generates NaNs."""


### PR DESCRIPTION
To enable sampling backwards compatibility for SDV, we need to be able to handle the situation where an old transformer (without the `cardinality_rule` attribute) is loaded in from the pkl file. Here, we fall back to the old `enforce_uniqueness` behavior. 