### PR TITLE
Refactoring code for Enterprise issue #529

### DIFF
--- a/rdt/transformers/text.py
+++ b/rdt/transformers/text.py
@@ -216,7 +216,7 @@ class RegexGenerator(BaseTransformer):
             try:
                 generated_values.append(next(self.generator))
                 self.generated += 1
-            except Exception:  # pylint: disable=broad-exception-caught
+            except StopIteration:
                 # Can't generate more rows without collision so breaking out of loop
                 break
 

--- a/rdt/transformers/text.py
+++ b/rdt/transformers/text.py
@@ -189,6 +189,9 @@ class RegexGenerator(BaseTransformer):
                 f'values (only {max(remaining, 0)} unique values left).'
             )
 
+    def _get_remaining_generator_values(self):
+        return list(self.generator)
+
     def _reverse_transform(self, data):
         """Generate new data using the provided ``regex_format``.
 
@@ -216,9 +219,9 @@ class RegexGenerator(BaseTransformer):
             self.generated += sample_size
 
         else:
-            generated_values = list(self.generator)
+            generated_values = self._get_remaining_generator_values()
             reverse_transformed = generated_values[:]
-            self.generated = self.generator_size
+            self.generated += len(generated_values)
             if self.enforce_uniqueness:
                 try:
                     remaining_samples = sample_size - len(reverse_transformed)

--- a/rdt/transformers/text.py
+++ b/rdt/transformers/text.py
@@ -189,9 +189,6 @@ class RegexGenerator(BaseTransformer):
                 f'values (only {max(remaining, 0)} unique values left).'
             )
 
-    def _get_remaining_generator_values(self):
-        return list(self.generator)
-
     def _reverse_transform(self, data):
         """Generate new data using the provided ``regex_format``.
 
@@ -214,14 +211,18 @@ class RegexGenerator(BaseTransformer):
             self.reset_randomization()
             remaining = self.generator_size
 
-        if remaining >= sample_size:
-            reverse_transformed = [next(self.generator) for _ in range(sample_size)]
-            self.generated += sample_size
+        generated_values = []
+        while len(generated_values) < sample_size:
+            try:
+                generated_values.append(next(self.generator))
+                self.generated += 1
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Can't generate more rows without collision so breaking out of loop
+                break
 
-        else:
-            generated_values = self._get_remaining_generator_values()
-            reverse_transformed = generated_values[:]
-            self.generated += len(generated_values)
+        reverse_transformed = generated_values[:]
+
+        if len(reverse_transformed) < sample_size:
             if self.enforce_uniqueness:
                 try:
                     remaining_samples = sample_size - len(reverse_transformed)

--- a/rdt/transformers/text.py
+++ b/rdt/transformers/text.py
@@ -216,7 +216,7 @@ class RegexGenerator(BaseTransformer):
             try:
                 generated_values.append(next(self.generator))
                 self.generated += 1
-            except StopIteration:
+            except (RuntimeError, StopIteration):
                 # Can't generate more rows without collision so breaking out of loop
                 break
 


### PR DESCRIPTION
This PR alters the logic of `_reverse_transform` so that it can work naturally with the random regex transformer.

The previous logic was:
1. If the amount of values the generator has left is more than the number of samples asked for, sample them all.
2. If the amount of values the generator has left is less than the number of sample asked for, sample the rest of the generator.
    - If `enforce_uniqueness` is enabled, then add suffixes to old values to make more.
    - If `enforce_uniqueness` is disabled, copy previous values

This doesn't work for the random regex generator for two reasons:
1. It can't always sample all the values because it has collisions
2. You can't easily get all "remaining" values because technically it's unlimited.

The new logic that should work for both cases is
1. Sample as many values from the generator as you can until you either get enough or hit an exception.
    - The exception means the generator either ran out (in the not random case) or we had too many collisions (in the random case)
2. If more values are required, add them by:
    - If `enforce_uniqueness` is enabled, then add suffixes to old values to make more.
    - If `enforce_uniqueness` is disabled, copy previous values

CU-86b04th7c