### PR TITLE
[dtypes] `FloatFormatter` reverse transform does not support new pandas dtypes

### DIFF
--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -188,13 +188,14 @@ class FloatFormatter(BaseTransformer):
             min_bound, max_bound = INTEGER_BOUNDS[self.computer_representation]
             data = data.clip(min_bound, max_bound)
 
-        is_integer = np.dtype(self._dtype).kind == 'i'
+        is_integer = pd.api.types.is_integer_dtype(self._dtype)
+        is_pandas_instance = isinstance(data, (pd.Series, pd.DataFrame))
         if self.learn_rounding_scheme and self._rounding_digits is not None:
             data = data.round(self._rounding_digits)
         elif is_integer:
             data = data.round(0)
 
-        if pd.isna(data).any() and is_integer:
+        if pd.isna(data).any() and is_integer and not is_pandas_instance:
             return data
 
         return data.astype(self._dtype)

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -103,7 +103,7 @@ class FloatFormatter(BaseTransformer):
         )
 
     def _validate_values_within_bounds(self, data):
-        if self.computer_representation != 'Float':
+        if not self.computer_representation.startswith('Float'):
             fractions = data[~data.isna() & data % 1 != 0]
             if not fractions.empty:
                 raise ValueError(
@@ -184,7 +184,7 @@ class FloatFormatter(BaseTransformer):
         data = self.null_transformer.reverse_transform(data)
         if self.enforce_min_max_values:
             data = data.clip(self._min_value, self._max_value)
-        elif self.computer_representation != 'Float':
+        elif not self.computer_representation.startswith('Float'):
             min_bound, max_bound = INTEGER_BOUNDS[self.computer_representation]
             data = data.clip(min_bound, max_bound)
 

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -189,16 +189,13 @@ class FloatFormatter(BaseTransformer):
             data = data.clip(min_bound, max_bound)
 
         is_integer = pd.api.types.is_integer_dtype(self._dtype)
-        is_pandas_instance = isinstance(data, (pd.Series, pd.DataFrame))
+        np_integer_with_nans = isinstance(data, np.ndarray) and is_integer and pd.isna(data).any()
         if self.learn_rounding_scheme and self._rounding_digits is not None:
             data = data.round(self._rounding_digits)
         elif is_integer:
             data = data.round(0)
 
-        if pd.isna(data).any() and is_integer and not is_pandas_instance:
-            return data
-
-        return data.astype(self._dtype)
+        return data.astype(self._dtype if not np_integer_with_nans else 'float64')
 
     def _set_fitted_parameters(
         self,

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -251,8 +251,8 @@ class TestFloatFormatter:
         # Assert
         pd.testing.assert_series_equal(compare_output['column_name'], compare_data['column_name'])
 
-    def test__support_new_pandas_dtypes(self):
-        """Test that the transformer supports the new pandas dtypes."""
+    def test__support__nullable_numerical_pandas_dtypes(self):
+        """Test that the transformer supports the nullable numerical pandas dtypes."""
         # Setup
         data = pd.DataFrame({
             'Int8': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int8'),

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -259,10 +259,18 @@ class TestFloatFormatter:
             'Int16': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int16'),
             'Int32': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int32'),
             'Int64': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int64'),
-            'Float32': pd.Series([1.1, 2.2, 3.3, pd.NA, None, pd.NA], dtype='Float32'),
-            'Float64': pd.Series([1.1, 2.2, 3.3, pd.NA, None, pd.NA], dtype='Float64'),
+            'Float32': pd.Series([1.123, 2.23, 3.3, pd.NA, None, pd.NA], dtype='Float32'),
+            'Float64': pd.Series([1.1234, 2.234, 3.33, pd.NA, None, pd.NA], dtype='Float64'),
         })
-        ff = FloatFormatter()
+        ff = FloatFormatter(learn_rounding_scheme=True)
+        expected_rounding_digits = {
+            'Int8': 0,
+            'Int16': 0,
+            'Int32': 0,
+            'Int64': 0,
+            'Float32': 3,
+            'Float64': 4,
+        }
 
         # Run and Assert
         for column in data.columns:
@@ -273,6 +281,11 @@ class TestFloatFormatter:
             assert transformed[column].dtype == 'float64'
             assert reverse_transformed[column].dtype == data[column].dtype
             assert reverse_transformed[column].isna().any()
+            assert ff._rounding_digits == expected_rounding_digits[column]
+            pd.testing.assert_series_equal(
+                reverse_transformed[column],
+                reverse_transformed[column].round(expected_rounding_digits[column]),
+            )
 
 
 class TestGaussianNormalizer:

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -165,7 +165,7 @@ class TestFloatFormatter:
     def test__reverse_transform_from_manually_set_parameters(self):
         """Test the ``reverse_transform`` after manually setting parameters."""
         # Setup
-        data = pd.DataFrame({'column_name': [1, 2, 1, 3, 12, 9, 8]})
+        data = pd.DataFrame({'column_name': pd.Series([1, 2, 1, 3, 12, 9, 8], dtype='int64')})
         transformed = pd.DataFrame({
             'column_name': [1.000, 2.000, 1.000, 3.000, 12.000, 9.000, 8.000]
         })
@@ -192,7 +192,9 @@ class TestFloatFormatter:
     def test__reverse_transform_from_manually_set_parameters_from_column(self):
         """Test the ``reverse_transform`` after manually setting parameters."""
         # Setup
-        data = pd.DataFrame({'column_name': [1, 2, np.nan, 3, 12, np.nan, 8]})
+        data = pd.DataFrame({
+            'column_name': pd.Series([1, 2, np.nan, 3, 12, np.nan, 8], dtype='Int64')
+        })
         transformed = pd.DataFrame({
             'column_name': [1.000, 2.000, 1.000, 3.000, 12.000, 9.000, 8.000],
             'column_name.is_null': [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0],
@@ -203,7 +205,7 @@ class TestFloatFormatter:
         null_transformer._set_fitted_parameters(0.2)
         min_max_value = (0.0, 100.0)
         rounding_digits = 3
-        dtype = 'int64'
+        dtype = 'Int64'
 
         # Run
         transformer._set_fitted_parameters(
@@ -221,7 +223,7 @@ class TestFloatFormatter:
     def test__reverse_transform_from_manually_set_parameters_random(self):
         """Test the ``reverse_transform`` after manually setting parameters."""
         # Setup
-        data = pd.DataFrame({'column_name': [1, 2, 1, 3, 12, 9, 8, 4]})
+        data = pd.DataFrame({'column_name': pd.Series([1, 2, 1, 3, 12, 9, 8, 4], dtype='Int64')})
         transformed = pd.DataFrame({
             'column_name': [1.000, 2.000, 1.000, 3.000, 12.000, 9.000, 8.000, 4.000]
         })
@@ -231,7 +233,7 @@ class TestFloatFormatter:
         null_transformer._set_fitted_parameters(0.2)
         min_max_value = (0.0, 100.0)
         rounding_digits = 3
-        dtype = 'int64'
+        dtype = 'Int64'
 
         # Run
         transformer._set_fitted_parameters(
@@ -244,10 +246,33 @@ class TestFloatFormatter:
         output = transformer.reverse_transform(transformed)
         nan_indices = output[output.isna().any(axis=1)].index
         compare_data = data.drop(index=nan_indices)
-        compare_output = output.drop(index=nan_indices).astype('int64')
+        compare_output = output.drop(index=nan_indices)
 
         # Assert
         pd.testing.assert_series_equal(compare_output['column_name'], compare_data['column_name'])
+
+    def test__support_new_pandas_dtypes(self):
+        """Test that the transformer supports the new pandas dtypes."""
+        # Setup
+        data = pd.DataFrame({
+            'Int8': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int8'),
+            'Int16': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int16'),
+            'Int32': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int32'),
+            'Int64': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int64'),
+            'Float32': pd.Series([1.1, 2.2, 3.3, np.nan, None, np.nan], dtype='Float32'),
+            'Float64': pd.Series([1.1, 2.2, 3.3, np.nan, None, np.nan], dtype='Float64'),
+        })
+        ff = FloatFormatter()
+
+        # Run and Assert
+        for column in data.columns:
+            ff.fit(data, column)
+            transformed = ff.transform(data)
+            reverse_transformed = ff.reverse_transform(transformed)
+
+            assert transformed[column].dtype == 'float64'
+            assert reverse_transformed[column].dtype == data[column].dtype
+            assert reverse_transformed[column].isna().any()
 
 
 class TestGaussianNormalizer:

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -255,12 +255,12 @@ class TestFloatFormatter:
         """Test that the transformer supports the new pandas dtypes."""
         # Setup
         data = pd.DataFrame({
-            'Int8': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int8'),
-            'Int16': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int16'),
-            'Int32': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int32'),
-            'Int64': pd.Series([1, 2, -3, np.nan, None, np.nan], dtype='Int64'),
-            'Float32': pd.Series([1.1, 2.2, 3.3, np.nan, None, np.nan], dtype='Float32'),
-            'Float64': pd.Series([1.1, 2.2, 3.3, np.nan, None, np.nan], dtype='Float64'),
+            'Int8': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int8'),
+            'Int16': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int16'),
+            'Int32': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int32'),
+            'Int64': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int64'),
+            'Float32': pd.Series([1.1, 2.2, 3.3, pd.NA, None, pd.NA], dtype='Float32'),
+            'Float64': pd.Series([1.1, 2.2, 3.3, pd.NA, None, pd.NA], dtype='Float64'),
         })
         ff = FloatFormatter()
 

--- a/tests/integration/transformers/test_numerical.py
+++ b/tests/integration/transformers/test_numerical.py
@@ -262,7 +262,6 @@ class TestFloatFormatter:
             'Float32': pd.Series([1.123, 2.23, 3.3, pd.NA, None, pd.NA], dtype='Float32'),
             'Float64': pd.Series([1.1234, 2.234, 3.33, pd.NA, None, pd.NA], dtype='Float64'),
         })
-        ff = FloatFormatter(learn_rounding_scheme=True)
         expected_rounding_digits = {
             'Int8': 0,
             'Int16': 0,
@@ -274,6 +273,7 @@ class TestFloatFormatter:
 
         # Run and Assert
         for column in data.columns:
+            ff = FloatFormatter(learn_rounding_scheme=True, computer_representation=column)
             ff.fit(data, column)
             transformed = ff.transform(data)
             reverse_transformed = ff.reverse_transform(transformed)

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -271,8 +271,8 @@ def test_learn_rounding_digits_all_missing_value_replacements():
     assert output is None
 
 
-def test_learn_rounding_digits_new_pandas_dtypes():
-    """Test that ``learn_rounding_digits`` supports the new pandas dtypes."""
+def test_learn_rounding_digits_nullable_numerical_pandas_dtypes():
+    """Test that ``learn_rounding_digits`` supports the nullable numerical pandas dtypes."""
     # Setup
     data = pd.DataFrame({
         'Int8': pd.Series([1, 2, -3, pd.NA, None, pd.NA], dtype='Int8'),


### PR DESCRIPTION
CU-86b1gcgpc
Resolve #855
