### PR TITLE
Fix `NotImplementedError` when using FloatFormatter with numerical data types during fit due to PyArrow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ test = [
     'rundoc>=0.4.3,<0.5',
     'pytest-subtests>=0.5,<1.0',
     'pytest-runner >= 2.11.1',
-    'pyarrow',
+    'pyarrow >= 17.0.0',
     'tomli>=2.0.0,<3',
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,9 @@ rdt = { main = 'rdt.cli.__main__:main' }
 
 [project.optional-dependencies]
 copulas = ['copulas>=0.11.0',]
+pyarrow = ['pyarrow>=17.0.0']
 test = [
+    'rdt[pyarrow]',
     'rdt[copulas]',
 
     'pytest>=3.4.2',
@@ -58,7 +60,6 @@ test = [
     'rundoc>=0.4.3,<0.5',
     'pytest-subtests>=0.5,<1.0',
     'pytest-runner >= 2.11.1',
-    'pyarrow >= 17.0.0',
     'tomli>=2.0.0,<3',
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     'rundoc>=0.4.3,<0.5',
     'pytest-subtests>=0.5,<1.0',
     'pytest-runner >= 2.11.1',
+    'pyarrow',
     'tomli>=2.0.0,<3',
 ]
 dev = [

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -104,7 +104,7 @@ class FloatFormatter(BaseTransformer):
 
     def _validate_values_within_bounds(self, data):
         if not self.computer_representation.startswith('Float'):
-            fractions = data[~data.isna() & data % 1 != 0]
+            fractions = data[~data.isna() & (data != (data // 1))]
             if not fractions.empty:
                 raise ValueError(
                     f"The column '{data.name}' contains float values {fractions.tolist()}. "

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -252,8 +252,7 @@ def learn_rounding_digits(data):
         int or None:
             Number of digits to round to.
     """
-    name = data.name
-    if isinstance(data.dtype, pd.ArrowDtype):
+    if str(data.dtype).endswith("[pyarrow]"):
         data = data.to_numpy()
 
     # check if data has any decimals
@@ -276,7 +275,7 @@ def learn_rounding_digits(data):
     # Can't round, not equal after MAX_DECIMALS digits of precision
     LOGGER.info(
         "No rounding scheme detected for column '%s'. Data will not be rounded.",
-        name,
+        data.name,
     )
     return None
 

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -261,7 +261,7 @@ def learn_rounding_digits(data):
         return None
 
     # Doesn't contain decimal digits
-    if ((roundable_data % 1) == 0).all():
+    if (roundable_data == roundable_data.astype(int)).all():
         return 0
 
     # Try to round to fewer digits

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -252,8 +252,11 @@ def learn_rounding_digits(data):
         int or None:
             Number of digits to round to.
     """
-    # check if data has any decimals
     name = data.name
+    if isinstance(data.dtype, pd.ArrowDtype):
+        data = data.to_numpy()
+
+    # check if data has any decimals
     roundable_data = data[~(np.isinf(data.astype(float)) | pd.isna(data))]
 
     # Doesn't contain numbers

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -252,6 +252,7 @@ def learn_rounding_digits(data):
         int or None:
             Number of digits to round to.
     """
+    # check it ends with pyarrow
     if str(data.dtype).endswith("[pyarrow]"):
         data = data.to_numpy()
 

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -252,11 +252,10 @@ def learn_rounding_digits(data):
         int or None:
             Number of digits to round to.
     """
-    # check it ends with pyarrow
-    if str(data.dtype).endswith("[pyarrow]"):
-        data = data.to_numpy()
-
     # check if data has any decimals
+    name = data.name
+    if str(data.dtype).endswith('[pyarrow]'):
+        data = data.to_numpy()
     roundable_data = data[~(np.isinf(data.astype(float)) | pd.isna(data))]
 
     # Doesn't contain numbers
@@ -276,7 +275,7 @@ def learn_rounding_digits(data):
     # Can't round, not equal after MAX_DECIMALS digits of precision
     LOGGER.info(
         "No rounding scheme detected for column '%s'. Data will not be rounded.",
-        data.name,
+        name,
     )
     return None
 

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import copulas
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 from copulas import univariate
 from pandas.api.types import is_float_dtype
@@ -38,6 +39,16 @@ class TestFloatFormatter(TestCase):
         """
         # Setup
         data = pd.Series([15, None, 25])
+        transformer = FloatFormatter()
+        transformer.computer_representation = 'UInt8'
+
+        # Run
+        transformer._validate_values_within_bounds(data)
+
+    def test__validate_values_within_bounds_pyarrow(self):
+        """Test it works with pyarrow."""
+        # Setup
+        data = pd.Series(range(10), dtype='int64[pyarrow]')
         transformer = FloatFormatter()
         transformer.computer_representation = 'UInt8'
 

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -47,7 +47,10 @@ class TestFloatFormatter(TestCase):
     def test__validate_values_within_bounds_pyarrow(self):
         """Test it works with pyarrow."""
         # Setup
-        data = pd.Series(range(10), dtype='int64[pyarrow]')
+        try:
+            data = pd.Series(range(10), dtype='int64[pyarrow]')
+        except TypeError:
+            pytest.skip("Skipping as old numpy/pandas versions don't support arrow")
         transformer = FloatFormatter()
         transformer.computer_representation = 'UInt8'
 

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 import copulas
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 import pytest
 from copulas import univariate
 from pandas.api.types import is_float_dtype

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -228,7 +228,10 @@ def test_learn_rounding_digits_less_than_15_decimals():
 def test_learn_rounding_digits_pyarrow():
     """Test it works with pyarrow."""
     # Setup
-    data = pd.Series(range(10), dtype='int64[pyarrow]')
+    try:
+        data = pd.Series(range(10), dtype='int64[pyarrow]')
+    except TypeError:
+        pytest.skip("Skipping as old numpy/pandas versions don't support arrow")
 
     # Run
     output = learn_rounding_digits(data)
@@ -240,7 +243,10 @@ def test_learn_rounding_digits_pyarrow():
 def test_learn_rounding_digits_pyarrow_float():
     """Test it learns the proper amount of digits with pyarrow."""
     # Setup
-    data = pd.Series([0.5, 0.19, 3], dtype='float64[pyarrow]')
+    try:
+        data = pd.Series([0.5, 0.19, 3], dtype='float64[pyarrow]')
+    except TypeError:
+        pytest.skip("Skipping as old numpy/pandas versions don't support arrow")
 
     # Run
     output = learn_rounding_digits(data)

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from rdt.transformers.utils import (
@@ -223,6 +224,18 @@ def test_learn_rounding_digits_less_than_15_decimals():
     output = learn_rounding_digits(data)
 
     assert output == 3
+
+
+def test_learn_rounding_digits_pyarrow():
+    """Test it works with pyarrow."""
+    # Setup
+    data = pd.Series(range(10), dtype='int64[pyarrow]')
+
+    # Run
+    output = learn_rounding_digits(data)
+
+    # Assert
+    assert output == 0
 
 
 def test_learn_rounding_digits_negative_decimals_float():

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 import pytest
 
 from rdt.transformers.utils import (
@@ -236,6 +235,18 @@ def test_learn_rounding_digits_pyarrow():
 
     # Assert
     assert output == 0
+
+
+def test_learn_rounding_digits_pyarrow_float():
+    """Test it learns the proper amount of digits with pyarrow."""
+    # Setup
+    data = pd.Series([0.5, 0.19, 3], dtype='float64[pyarrow]')
+
+    # Run
+    output = learn_rounding_digits(data)
+
+    # Assert
+    assert output == 2
 
 
 def test_learn_rounding_digits_negative_decimals_float():

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -1,7 +1,7 @@
 import sre_parse
 import warnings
 from sre_constants import MAXREPEAT
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -327,6 +327,20 @@ def test_learn_rounding_digits_nullable_numerical_pandas_dtypes():
     for column in data.columns:
         output = learn_rounding_digits(data[column])
         assert output == expected_output[column]
+
+
+def test_learn_rounding_digits_pyarrow_to_numpy():
+    """Test that ``learn_rounding_digits`` works with pyarrow to numpy conversion."""
+    # Setup
+    data = Mock()
+    data.dtype = 'int64[pyarrow]'
+    data.to_numpy.return_value = np.array([1, 2, 3])
+
+    # Run
+    learn_rounding_digits(data)
+
+    # Assert
+    assert data.to_numpy.called
 
 
 def test_warn_dict():


### PR DESCRIPTION
CU-86b2bhp27, Resolve #886.