### PR TITLE
Exclude scripts directory from bandit

### DIFF
--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install bandit==1.7.7
     - name: Save code analysis
-      run: bandit -r . -x ./tests -f txt -o static_code_analysis.txt --exit-zero
+      run: bandit -r . -x ./tests,./scripts -f txt -o static_code_analysis.txt --exit-zero
     - name: Create pull request
       id: cpr
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
- Noticed in https://github.com/sdv-dev/RDT/pull/892 that a file in scripts was raising a false warning so excluding the scripts directory
  - See https://github.com/sdv-dev/RDT/pull/892/files#diff-93f4ec97f07b29489174ee0e652584729d9502325c82e39aa765d5c839c38f31R4