### PR TITLE
Autofix: Wrong code in _set_seed of BaseTransformer?

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -367,9 +367,8 @@ class BaseTransformer:
 
     def _set_seed(self, data):
         hash_value = self.columns[0]
-        for value in data.head(5):
-            hash_value += str(value)
-
+        for _, row in data.head(5).iterrows():
+            hash_value += str(row[self.columns[0]])
         hash_value = int(hashlib.sha256(hash_value.encode('utf-8')).hexdigest(), 16)
         self.random_seed = hash_value % ((2**32) - 1)  # maximum value for a seed
         self.random_states = {


### PR DESCRIPTION
Modified the _set_seed method to use the actual values from the first column instead of just the column names. This ensures that the seed is based on the data content rather than just the column names. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    