### PR TITLE
Bump Python Version for `codecov` report

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,5 +35,5 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         flags: integration
-        file: './integration_cov.xml'
+        file: ${{ github.workspace }}./integration_cov.xml
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,5 +35,6 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         flags: integration
-        file: ${{ github.workspace }}./integration_cov.xml
+        file: ${{ github.workspace }}/integration_cov.xml
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run integration tests
       run: invoke integration
 
-    - if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+    - if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.12
       name: Upload integration codecov report
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run Unit tests
       run: invoke unit
 
-    - if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+    - if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.12
       name: Upload unit codecov report
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,4 +38,5 @@ jobs:
       with:
         flags: unit
         file: ${{ github.workspace }}/unit_cov.xml
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -37,5 +37,5 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         flags: unit
-        file: './unit_cov.xml'
+        file: ${{ github.workspace }}/unit_cov.xml
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
As part of #898 
Bump the python version for the workflow