### PR TITLE
Cancel previous workflow runs on a new push

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   minimum:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -9,6 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
 jobs:
   minimum:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -9,7 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   minimum:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
CU-86b3ffpzh
Resolve #927
When pushing a new commit to a PR, cancel old jobs in progress