### PR TITLE
Set random as default missing value replacement for timestamp encoders

### DIFF
--- a/rdt/transformers/boolean.py
+++ b/rdt/transformers/boolean.py
@@ -16,7 +16,7 @@ class BinaryEncoder(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If the string ``'mode'`` is given,
             replace them with the most common value.
             Defaults to ``mode``.

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -23,7 +23,7 @@ class UnixTimestampEncoder(BaseTransformer):
             Indicate what to replace the null values with. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation, if ``'random'``, use
             random values from the dataset to fill the nan values.
-            Defaults to ``mean``.
+            Defaults to ``random``.
         model_missing_values (bool):
             **DEPRECATED** Whether to create a new column to indicate which values were null or
             not. The column will be created only if there are null values. If ``True``, create
@@ -53,14 +53,14 @@ class UnixTimestampEncoder(BaseTransformer):
 
     def __init__(
         self,
-        missing_value_replacement='mean',
+        missing_value_replacement='random',
         model_missing_values=None,
         datetime_format=None,
         missing_value_generation='random',
         enforce_min_max_values=False,
     ):
         super().__init__()
-        self._set_missing_value_replacement('mean', missing_value_replacement)
+        self._set_missing_value_replacement('random', missing_value_replacement)
         self._set_missing_value_generation(missing_value_generation)
         self.enforce_min_max_values = enforce_min_max_values
         if model_missing_values is not None:
@@ -248,7 +248,7 @@ class OptimizedTimestampEncoder(UnixTimestampEncoder):
             Indicate what to replace the null values with. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation, if ``'random'``, use
             random values from the dataset to fill the nan values.
-            Defaults to ``mean``.
+            Defaults to ``random``.
         model_missing_values (bool):
             **DEPRECATED** Whether to create a new column to indicate which values were null or
             not. The column will be created only if there are null values. If ``True``, create
@@ -275,7 +275,7 @@ class OptimizedTimestampEncoder(UnixTimestampEncoder):
 
     def __init__(
         self,
-        missing_value_replacement=None,
+        missing_value_replacement='random',
         model_missing_values=None,
         datetime_format=None,
         missing_value_generation='random',

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -19,7 +19,7 @@ class UnixTimestampEncoder(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (str, object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation, if ``'random'``, use
             random values from the dataset to fill the nan values.
@@ -244,7 +244,7 @@ class OptimizedTimestampEncoder(UnixTimestampEncoder):
     This class behaves exactly as the ``UnixTimestampEncoder`` except with the optimization.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation, if ``'random'``, use
             random values from the dataset to fill the nan values.

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -19,7 +19,7 @@ class UnixTimestampEncoder(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (str, object):
             Indicate what to replace the null values with. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation, if ``'random'``, use
             random values from the dataset to fill the nan values.

--- a/rdt/transformers/null.py
+++ b/rdt/transformers/null.py
@@ -14,7 +14,7 @@ class NullTransformer:
     """Transformer for data that contains Null values.
 
     Args:
-        missing_value_replacement (object or None):
+        missing_value_replacement (object, str, or None):
             Indicate what to do with the null values. If an integer, float or string is given,
             replace them with the given value. If the strings ``'mean'`` or ``'mode'`` are given,
             replace them with the corresponding aggregation (``'mean'`` only works for numerical

--- a/rdt/transformers/numerical.py
+++ b/rdt/transformers/numerical.py
@@ -35,7 +35,7 @@ class FloatFormatter(BaseTransformer):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If an integer or float is given,
             replace them with the given value. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation and if ``'random'``
@@ -638,7 +638,7 @@ class LogitScaler(FloatFormatter):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If an integer or float is given,
             replace them with the given value. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation and if ``'random'``
@@ -740,7 +740,7 @@ class LogScaler(FloatFormatter):
     Null values are replaced using a ``NullTransformer``.
 
     Args:
-        missing_value_replacement (object):
+        missing_value_replacement (object, str):
             Indicate what to replace the null values with. If an integer or float is given,
             replace them with the given value. If the strings ``'mean'`` or ``'mode'``
             are given, replace them with the corresponding aggregation and if ``'random'``

--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,7 @@ def check_dependencies(c):
 def unit(c):
     c.run(
         'python -m pytest ./tests/unit ./tests/performance/tests ./tests/datasets/tests '
-        '--cov=rdt --cov-fail-under=100 --cov-report=xml:./unit_cov.xml'
+        '--cov=rdt --cov-fail-under=100 --cov-report term-missing --cov-report=xml:./unit_cov.xml'
     )
 
 

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -221,6 +221,8 @@ class TestHyperTransformer:
             '2010-01-01',
             '2010-01-01',
         ])
+        max_datetime = max(datetimes.dropna())
+        min_datetime = min(datetimes.dropna())
         data = pd.DataFrame(
             {
                 'integer': [1, 2, 1, 3, 1, 4, 2, 3],
@@ -293,7 +295,7 @@ class TestHyperTransformer:
                     0.3024284729840169,
                 ],
                 'datetime': [
-                    1.2630692571428572e18,
+                    1.2631629169758298e+18,
                     1.2649824e18,
                     1.262304e18,
                     1.262304e18,
@@ -349,8 +351,16 @@ class TestHyperTransformer:
         )
         for row in range(reverse_transformed.shape[0]):
             for column in range(reverse_transformed.shape[1]):
+                column_name = reverse_transformed.columns[column]
                 expected = expected_reversed.iloc[row, column]
                 actual = reverse_transformed.iloc[row, column]
+                if pd.isna(expected):
+                    assert pd.isna(actual)
+                    continue
+                # if column_name == 'datetime':
+                #     #
+                #     assert min_datetime <= actual <= max_datetime
+                #     continue
                 assert pd.isna(actual) or expected == actual
 
         assert isinstance(ht.field_transformers['integer'], FloatFormatter)

--- a/tests/integration/test_hyper_transformer.py
+++ b/tests/integration/test_hyper_transformer.py
@@ -221,8 +221,6 @@ class TestHyperTransformer:
             '2010-01-01',
             '2010-01-01',
         ])
-        max_datetime = max(datetimes.dropna())
-        min_datetime = min(datetimes.dropna())
         data = pd.DataFrame(
             {
                 'integer': [1, 2, 1, 3, 1, 4, 2, 3],
@@ -295,7 +293,7 @@ class TestHyperTransformer:
                     0.3024284729840169,
                 ],
                 'datetime': [
-                    1.2631629169758298e+18,
+                    1.2631629169758298e18,
                     1.2649824e18,
                     1.262304e18,
                     1.262304e18,
@@ -320,7 +318,7 @@ class TestHyperTransformer:
         pd.testing.assert_frame_equal(transformed, expected_transformed)
 
         reversed_datetimes = pd.to_datetime([
-            '2010-01-09',
+            '2010-01-10',
             np.nan,
             '2010-01-01',
             '2010-01-01',
@@ -351,16 +349,8 @@ class TestHyperTransformer:
         )
         for row in range(reverse_transformed.shape[0]):
             for column in range(reverse_transformed.shape[1]):
-                column_name = reverse_transformed.columns[column]
                 expected = expected_reversed.iloc[row, column]
                 actual = reverse_transformed.iloc[row, column]
-                if pd.isna(expected):
-                    assert pd.isna(actual)
-                    continue
-                # if column_name == 'datetime':
-                #     #
-                #     assert min_datetime <= actual <= max_datetime
-                #     continue
                 assert pd.isna(actual) or expected == actual
 
         assert isinstance(ht.field_transformers['integer'], FloatFormatter)
@@ -1175,6 +1165,7 @@ class TestHyperTransformer:
             'credit_card': AnonymizedFaker('credit_card', 'credit_card_number'),
             'balance': ClusterBasedNormalizer(max_clusters=3),
             'name': RegexGenerator(),
+            'signup_day': UnixTimestampEncoder(missing_value_replacement='mean'),
         })
         ht.update_transformers_by_sdtype(
             'categorical',

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -285,6 +285,7 @@ class TestBaseTransformer:
         transformer._set_missing_value_replacement(default=default, missing_value_replacement=None)
 
         # Assert
+        assert transformer.missing_value_replacement == default
         mock_warnings.warn.assert_called_once_with(
             (
                 "Setting 'missing_value_replacement' to 'None' is no longer supported. "

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -275,6 +275,25 @@ class TestBaseTransformer:
             BaseTransformer._set_missing_value_generation(instance, 'None')
 
     @patch('rdt.transformers.base.warnings')
+    def test__set_missing_value_replacement(self, mock_warnings):
+        """Test that ``_set_missing_value_replacement`` raises a warning if value is None."""
+        # Setup
+        transformer = BaseTransformer()
+        default = 'random'
+
+        # Run
+        transformer._set_missing_value_replacement(default=default, missing_value_replacement=None)
+
+        # Assert
+        mock_warnings.warn.assert_called_once_with(
+            (
+                "Setting 'missing_value_replacement' to 'None' is no longer supported. "
+                f"Imputing with the '{default}' instead."
+            ),
+            FutureWarning,
+        )
+
+    @patch('rdt.transformers.base.warnings')
     def test_model_missing_values(self, mock_warnings):
         """Test ``model_missing_values`` property.
 

--- a/tests/unit/transformers/test_datetime.py
+++ b/tests/unit/transformers/test_datetime.py
@@ -45,6 +45,14 @@ class TestUnixTimestampEncoder:
         assert transformer.missing_value_generation == 'random'
         assert transformer.datetime_format == '%M-%d-%Y'
 
+    def test_default_missing_value_replacement(self):
+        """Test the default value of missing_value_replacement is 'random'"""
+        # Run
+        transformer = UnixTimestampEncoder()
+
+        # Assert
+        assert transformer.missing_value_replacement == 'random'
+
     def test__convert_to_datetime(self):
         """Test the ``_convert_to_datetime`` method.
 
@@ -270,7 +278,7 @@ class TestUnixTimestampEncoder:
         """
         # Setup
         data = pd.to_datetime(['2020-01-01', '2020-02-01', '2020-03-01'])
-        transformer = UnixTimestampEncoder()
+        transformer = UnixTimestampEncoder(missing_value_replacement='mean')
 
         # Run
         transformer._fit(data)
@@ -603,6 +611,14 @@ class TestOptimizedTimestampEncoder:
         assert transformer.datetime_format == '%M-%d-%Y'
         assert transformer.divider is None
         assert transformer.null_transformer is None
+
+    def test_default_missing_value_replacement(self):
+        """Test the default value of missing_value_replacement is 'random'"""
+        # Run
+        transformer = OptimizedTimestampEncoder()
+
+        # Assert
+        assert transformer.missing_value_replacement == 'random'
 
     def test__find_divider(self):
         """Test the ``_find_divider`` method.


### PR DESCRIPTION
- Fixes #937 