### PR TITLE
Allow sdtype id columns to use some of the categorical transformers

### DIFF
--- a/rdt/transformers/categorical.py
+++ b/rdt/transformers/categorical.py
@@ -40,7 +40,7 @@ class UniformEncoder(BaseTransformer):
     """
 
     INPUT_SDTYPE = 'categorical'
-    SUPPORTED_SDTYPES = ['categorical', 'boolean']
+    SUPPORTED_SDTYPES = ['categorical', 'boolean', 'id', 'text']
     frequencies = None
     intervals = None
     dtype = None
@@ -733,7 +733,7 @@ class LabelEncoder(BaseTransformer):
     """
 
     INPUT_SDTYPE = 'categorical'
-    SUPPORTED_SDTYPES = ['categorical', 'boolean']
+    SUPPORTED_SDTYPES = ['categorical', 'boolean', 'id', 'text']
     values_to_categories = None
     categories_to_values = None
     dtype = 'O'


### PR DESCRIPTION
Resolve #953 
CU-86b47rdu4

Tested locally and confirmed this change allows `UniformEncoder`, `OrderedUnifromEncoder`, `LabelEncoder`, and `OrderedLabelEncoder` to be set for columns with `id` sdtype.