### PR TITLE
Fix `BaseTransformer.__repr__` when transformer has required arguments

### DIFF
--- a/rdt/transformers/base.py
+++ b/rdt/transformers/base.py
@@ -327,19 +327,19 @@ class BaseTransformer:
         custom_args = []
         args = inspect.getfullargspec(self.__init__)
         keys = args.args[1:]
-        defaults = args.defaults or []
-        defaults = dict(zip(keys, defaults))
         instanced = {
             key: getattr(self, key)
             for key in keys
             if key != 'model_missing_values' and hasattr(self, key)  # Remove after deprecation
         }
 
+        defaults = args.defaults or []
+        defaults = dict(zip(keys, defaults))
         if defaults == instanced:
             return f'{class_name}()'
 
         for arg, value in instanced.items():
-            if defaults[arg] != value:
+            if arg not in defaults or defaults[arg] != value:
                 custom_args.append(f'{arg}={repr(value)}')
 
         args_string = ', '.join(custom_args)

--- a/tests/unit/transformers/test_base.py
+++ b/tests/unit/transformers/test_base.py
@@ -364,18 +364,19 @@ class TestBaseTransformer:
 
         # Setup
         class Dummy(BaseTransformer):
-            def __init__(self, param1=None, param2=None, param3=None):
+            def __init__(self, param0, param1=None, param2=None, param3=None):
+                self.param0 = param0
                 self.param1 = param1
                 self.param2 = param2
                 self.param3 = param3
 
-        transformer = Dummy(param2='value', param3=True)
+        transformer = Dummy(param0='required', param2='value', param3=True)
 
         # Run
         text = repr(transformer)
 
         # Assert
-        assert text == "Dummy(param2='value', param3=True)"
+        assert text == "Dummy(param0='required', param2='value', param3=True)"
 
     def test__str__(self):
         """Test the ``__str__`` method.


### PR DESCRIPTION
CU-86b4bz2r6, Resolve #961.