### PR TITLE
Improve `learn_rounding_digits` precision

### DIFF
--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -15,7 +15,7 @@ import sre_parse  # isort:skip
 
 LOGGER = logging.getLogger(__name__)
 
-MAX_DECIMALS = sys.float_info.dig - 1
+MAX_DECIMALS = sys.float_info.dig
 DEPRECATED_SDTYPES_MAPPING = {'text': 'id'}
 
 
@@ -279,8 +279,11 @@ def learn_rounding_digits(data):
         return 0
 
     # Try to round to fewer digits
-    if (roundable_data == roundable_data.round(MAX_DECIMALS)).all():
-        for decimal in range(MAX_DECIMALS + 1):
+    num_digits = len(str(int(np.max(np.abs(roundable_data)))))
+    max_rounding = MAX_DECIMALS - num_digits
+    rounded_data = roundable_data.round(max_rounding)
+    if np.isclose(roundable_data, rounded_data, atol=10**(-max_rounding - 1)).all():
+        for decimal in range(1, max_rounding + 1):
             if (roundable_data == roundable_data.round(decimal)).all():
                 return decimal
 

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -278,9 +278,10 @@ def learn_rounding_digits(data):
     highest_int = int(np.max(np.abs(roundable_data)))
     most_digits = len(str(highest_int)) if highest_int != 0 else 0
     max_decimals = max(0, MAX_DECIMALS - most_digits)
-    for decimal in range(max_decimals + 1):
-        if (roundable_data == roundable_data.round(decimal)).all():
-            return decimal
+    if (roundable_data == roundable_data.round(max_decimals)).all():
+        for decimal in range(max_decimals + 1):
+            if (roundable_data == roundable_data.round(decimal)).all():
+                return decimal
 
     # Can't round, not equal after MAX_DECIMALS digits of precision
     LOGGER.info(

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -270,22 +270,17 @@ def learn_rounding_digits(data):
         data = data.to_numpy()
     roundable_data = data[~(np.isinf(data.astype(float)) | pd.isna(data))]
 
-    # Doesn't contain numbers
+    # Empty dataset
     if len(roundable_data) == 0:
         return None
 
-    # Doesn't contain decimal digits
-    if (roundable_data == roundable_data.astype(int)).all():
-        return 0
-
     # Try to round to fewer digits
-    num_digits = len(str(int(np.max(np.abs(roundable_data)))))
-    max_rounding = MAX_DECIMALS - num_digits
-    rounded_data = roundable_data.round(max_rounding)
-    if np.isclose(roundable_data, rounded_data, atol=10**(-max_rounding - 1)).all():
-        for decimal in range(1, max_rounding + 1):
-            if (roundable_data == roundable_data.round(decimal)).all():
-                return decimal
+    highest_int = int(np.max(np.abs(roundable_data)))
+    most_digits = len(str(highest_int)) if highest_int != 0 else 0
+    max_decimals = max(0, MAX_DECIMALS - most_digits)
+    for decimal in range(max_decimals + 1):
+        if (roundable_data == roundable_data.round(decimal)).all():
+            return decimal
 
     # Can't round, not equal after MAX_DECIMALS digits of precision
     LOGGER.info(

--- a/tests/unit/transformers/test_numerical.py
+++ b/tests/unit/transformers/test_numerical.py
@@ -226,21 +226,9 @@ class TestFloatFormatter(TestCase):
         assert transformer._rounding_digits == 4
 
     def test__fit_learn_rounding_scheme_true_max_decimals(self):
-        """Test ``_fit`` with ``learn_rounding_scheme`` set to ``True``.
-
-        If the ``learn_rounding_scheme`` parameter is set to ``True``, ``_fit`` should learn
-        the ``_rounding_digits`` to be the max number of decimal places seen in the data.
-        The max amount of decimals that floats can be accurately compared with is 15.
-        If the input data has values with more than 14 decimals, we will not be able to
-        accurately learn the number of decimal places required, so we do not round.
-
-        Input:
-        - Series with a value that has 15 decimals
-        Side Effect:
-        - ``_rounding_digits`` is set to None
-        """
+        """Test ``_fit`` with ``learn_rounding_scheme`` set to ``True``."""
         # Setup
-        data = pd.Series([0.000000000000001])
+        data = pd.Series([0.0000000000000001])
 
         # Run
         transformer = FloatFormatter(missing_value_replacement='mean', learn_rounding_scheme=True)

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -223,17 +223,7 @@ def test_try_convert_to_dtype():
 
 
 def test_learn_rounding_digits_less_than_15_decimals():
-    """Test the learn_rounding_digits method with less than 15 decimals.
-
-    If the data has less than 15 decimals, the maximum number of decimals
-    should be returned.
-
-    Input:
-    - An array that contains floats with a maximum of 3 decimals and a
-        NaN.
-    Output:
-    - 3
-    """
+    """Test it for less than 15 decimals."""
     data = pd.Series(np.array([10, 0.0, 0.1, 0.12, 0.123, np.nan]))
 
     output = learn_rounding_digits(data)
@@ -241,8 +231,8 @@ def test_learn_rounding_digits_less_than_15_decimals():
     assert output == 3
 
 
-def test_learn_rounding_digits_high_digit_counts():
-    """Test it for high digit counts."""
+def test_learn_rounding_digits_high_integer_digits():
+    """Test it for high integer digits."""
     data = pd.Series(
         np.array([
             1.1,
@@ -267,16 +257,22 @@ def test_learn_rounding_digits_high_digit_counts():
     assert output == 1
 
 
-def test_learn_rounding_digits_too_many_digits():
+def test_learn_rounding_digits_very_high_integer_digits():
     """Test it for high digit counts."""
-    data = pd.Series(np.array([1234567890123456.7]))
+    data = pd.Series(
+        np.array([
+            1234567890123456.7,
+            12345678901234567.89,
+            123456789012345678.901,
+        ])
+    )
 
     output = learn_rounding_digits(data)
 
     assert output is None
 
 
-def test_learn_rounding_digits_too_many_digits2():
+def test_learn_rounding_digits_high_integer_and_decimals():
     """Test it for high digit counts."""
     data = pd.Series(np.array([123456789012345.6789]))
 
@@ -285,7 +281,7 @@ def test_learn_rounding_digits_too_many_digits2():
     assert output is None
 
 
-def test_learn_rounding_digits_too_many_digits3():
+def test_learn_rounding_digits_14_digits():
     """Test it for high digit counts."""
     data = pd.Series(np.array([12345678901.234]))
 
@@ -294,13 +290,13 @@ def test_learn_rounding_digits_too_many_digits3():
     assert output == 3
 
 
-def test_learn_rounding_digits_too_many_digits4():
+def test_learn_rounding_digits_15_digits():
     """Test it for high digit counts."""
-    data = pd.Series(np.array([12345678901.234]))
+    data = pd.Series(np.array([12345678901.2345]))
 
     output = learn_rounding_digits(data)
 
-    assert output == 3
+    assert output == 4
 
 
 def test_learn_rounding_digits_too_many_digits_no_int():
@@ -312,13 +308,67 @@ def test_learn_rounding_digits_too_many_digits_no_int():
     assert output is None
 
 
-def test_learn_rounding_digits_too_many_digits_no_int_fits():
+def test_learn_rounding_digits_many_decimlas():
     """Test it for high digit counts."""
-    data = pd.Series(np.array([0.12345678901234]))
+    data = pd.Series(np.array([0.123456789012345]))
 
     output = learn_rounding_digits(data)
 
-    assert output == 14
+    assert output == 15
+
+
+def test_learn_rounding_digits_integers():
+    """Test it for integers."""
+    data = pd.Series(np.array([123456789012345]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 0
+
+
+def test_learn_rounding_digits_integers_many_digits():
+    """Test it for integers."""
+    data = pd.Series(np.array([12345678901234567890]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 0
+
+
+def test_learn_rounding_digits_integers_many_digits_with_other_values():
+    """Test it for integers and decimals."""
+    data = pd.Series(np.array([12345678901234567890, 1.123]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_many_zeros():
+    """Test it for integers and decimals."""
+    data = pd.Series(np.array([0.000000000000000000001]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_negative_values():
+    """Test it for negative values."""
+    data = pd.Series(np.array([-12345678901234, -1.123]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_negative_value_15_decimals():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([-0.123456789012345]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 15
 
 
 def test_learn_rounding_digits_pyarrow():

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -222,22 +222,14 @@ def test_try_convert_to_dtype():
     pd.testing.assert_series_equal(output_convertibe, expected_data_convertibe)
 
 
-def test_learn_rounding_digits():
-    """Test it for various cases."""
-    # Setup
-    test_cases = [
-        # data_1: Basic decimal places test
+@pytest.mark.parametrize(
+    'test_data, expected_digits',
+    [
+        # Basic decimal places test
         (pd.Series([10, 0.0, 0.1, 0.12, 0.123, np.nan]), 3),
-        # data_2: Large numbers with decimals
-        (
-            pd.Series([
-                1234567890123456.7,
-                12345678901234567.89,
-                123456789012345678.901,
-            ]),
-            None,
-        ),
-        # data_3: Consistent single decimal place
+        # Large numbers with decimals
+        (pd.Series([1234567890123456.7, 12345678901234567.89, 123456789012345678.901]), None),
+        # Consistent single decimal place
         (
             pd.Series([
                 1.1,
@@ -257,31 +249,41 @@ def test_learn_rounding_digits():
             ]),
             1,
         ),
-        # data_4-8: Various precision tests
+        # Various precision tests
         (pd.Series([123456789012345.6789]), None),
         (pd.Series([12345678901.234]), 3),
         (pd.Series([12345678901.2345]), 4),
         (pd.Series([0.1234567890123456]), None),
         (pd.Series([0.123456789012345]), 15),
-        # data_9-10: Integer tests
+        # Integer tests
         (pd.Series([123456789012345]), 0),
         (pd.Series([12345678901234567890]), 0),
-        # data_11-14: Mixed number and edge cases
+        # Mixed number and edge cases
         (pd.Series([12345678901234567890, 1.123]), None),
         (pd.Series([0.000000000000000000001]), None),
         (pd.Series([-12345678901234, -1.123]), None),
         (pd.Series([-0.123456789012345]), 15),
-        # data_15-18: Tests with zeros and NaN
-        (pd.Series([1230.0, 12300.0, 123000.0, np.nan]), 0),
-        (pd.Series([1230, 12300, 123000, np.nan]), 0),
-        (pd.Series([np.nan, np.nan, np.nan, np.nan]), None),
-        (pd.Series([1234567890123.000, 12345678901234.000]), 0),
-    ]
+    ],
+)
+def test_learn_rounding_digits(test_data, expected_digits):
+    """Test learn_rounding_digits for various test cases."""
+    # Run
+    result = learn_rounding_digits(test_data)
 
-    # Run tests
-    for i, (data, expected) in enumerate(test_cases, 1):
-        output = learn_rounding_digits(data)
-        assert output == expected, f'Test case {i} failed: expected {expected}, got {output}'
+    # Assert
+    assert result == expected_digits
+
+
+def test_learn_rounding_digits_code_coverage():
+    """Test learn_rounding_digits for code coverage."""
+    # Setup
+    data = pd.Series([np.inf, -np.inf, np.nan])
+
+    # Run
+    result = learn_rounding_digits(data)
+
+    # Assert
+    assert result is None
 
 
 def test_learn_rounding_digits_pyarrow():

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -2,7 +2,7 @@ import sre_parse
 import warnings
 from decimal import Decimal
 from sre_constants import MAXREPEAT
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -222,24 +222,6 @@ def test_try_convert_to_dtype():
     pd.testing.assert_series_equal(output_convertibe, expected_data_convertibe)
 
 
-@patch('rdt.transformers.utils.LOGGER')
-def test_learn_rounding_digits_more_than_15_decimals(logger_mock):
-    """Test the learn_rounding_digits method with more than 15 decimals.
-
-    If the data has more than 15 decimals, return None and raise warning.
-    """
-    # Setup
-    data = pd.Series(np.random.random(size=10).round(20), name='col')
-
-    # Run
-    output = learn_rounding_digits(data)
-
-    # Assert
-    logger_msg = "No rounding scheme detected for column '%s'. Data will not be rounded."
-    logger_mock.info.assert_called_once_with(logger_msg, 'col')
-    assert output is None
-
-
 def test_learn_rounding_digits_less_than_15_decimals():
     """Test the learn_rounding_digits method with less than 15 decimals.
 
@@ -257,6 +239,86 @@ def test_learn_rounding_digits_less_than_15_decimals():
     output = learn_rounding_digits(data)
 
     assert output == 3
+
+
+def test_learn_rounding_digits_high_digit_counts():
+    """Test it for high digit counts."""
+    data = pd.Series(
+        np.array([
+            1.1,
+            11.1,
+            111.1,
+            1111.1,
+            11111.1,
+            111111.1,
+            1111111.1,
+            11111111.1,
+            111111111.1,
+            1111111111.1,
+            11111111111.1,
+            111111111111.1,
+            1111111111111.1,
+            11111111111111.1,
+        ])
+    )
+
+    output = learn_rounding_digits(data)
+
+    assert output == 1
+
+
+def test_learn_rounding_digits_too_many_digits():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([1234567890123456.7]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_too_many_digits2():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([123456789012345.6789]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_too_many_digits3():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([12345678901.234]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 3
+
+
+def test_learn_rounding_digits_too_many_digits4():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([12345678901.234]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 3
+
+
+def test_learn_rounding_digits_too_many_digits_no_int():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([0.1234567890123456]))
+
+    output = learn_rounding_digits(data)
+
+    assert output is None
+
+
+def test_learn_rounding_digits_too_many_digits_no_int_fits():
+    """Test it for high digit counts."""
+    data = pd.Series(np.array([0.12345678901234]))
+
+    output = learn_rounding_digits(data)
+
+    assert output == 14
 
 
 def test_learn_rounding_digits_pyarrow():

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -222,153 +222,66 @@ def test_try_convert_to_dtype():
     pd.testing.assert_series_equal(output_convertibe, expected_data_convertibe)
 
 
-def test_learn_rounding_digits_less_than_15_decimals():
-    """Test it for less than 15 decimals."""
-    data = pd.Series(np.array([10, 0.0, 0.1, 0.12, 0.123, np.nan]))
+def test_learn_rounding_digits():
+    """Test it for various cases."""
+    # Setup
+    test_cases = [
+        # data_1: Basic decimal places test
+        (pd.Series([10, 0.0, 0.1, 0.12, 0.123, np.nan]), 3),
+        # data_2: Large numbers with decimals
+        (
+            pd.Series([
+                1234567890123456.7,
+                12345678901234567.89,
+                123456789012345678.901,
+            ]),
+            None,
+        ),
+        # data_3: Consistent single decimal place
+        (
+            pd.Series([
+                1.1,
+                11.1,
+                111.1,
+                1111.1,
+                11111.1,
+                111111.1,
+                1111111.1,
+                11111111.1,
+                111111111.1,
+                1111111111.1,
+                11111111111.1,
+                111111111111.1,
+                1111111111111.1,
+                11111111111111.1,
+            ]),
+            1,
+        ),
+        # data_4-8: Various precision tests
+        (pd.Series([123456789012345.6789]), None),
+        (pd.Series([12345678901.234]), 3),
+        (pd.Series([12345678901.2345]), 4),
+        (pd.Series([0.1234567890123456]), None),
+        (pd.Series([0.123456789012345]), 15),
+        # data_9-10: Integer tests
+        (pd.Series([123456789012345]), 0),
+        (pd.Series([12345678901234567890]), 0),
+        # data_11-14: Mixed number and edge cases
+        (pd.Series([12345678901234567890, 1.123]), None),
+        (pd.Series([0.000000000000000000001]), None),
+        (pd.Series([-12345678901234, -1.123]), None),
+        (pd.Series([-0.123456789012345]), 15),
+        # data_15-18: Tests with zeros and NaN
+        (pd.Series([1230.0, 12300.0, 123000.0, np.nan]), 0),
+        (pd.Series([1230, 12300, 123000, np.nan]), 0),
+        (pd.Series([np.nan, np.nan, np.nan, np.nan]), None),
+        (pd.Series([1234567890123.000, 12345678901234.000]), 0),
+    ]
 
-    output = learn_rounding_digits(data)
-
-    assert output == 3
-
-
-def test_learn_rounding_digits_high_integer_digits():
-    """Test it for high integer digits."""
-    data = pd.Series(
-        np.array([
-            1.1,
-            11.1,
-            111.1,
-            1111.1,
-            11111.1,
-            111111.1,
-            1111111.1,
-            11111111.1,
-            111111111.1,
-            1111111111.1,
-            11111111111.1,
-            111111111111.1,
-            1111111111111.1,
-            11111111111111.1,
-        ])
-    )
-
-    output = learn_rounding_digits(data)
-
-    assert output == 1
-
-
-def test_learn_rounding_digits_very_high_integer_digits():
-    """Test it for high digit counts."""
-    data = pd.Series(
-        np.array([
-            1234567890123456.7,
-            12345678901234567.89,
-            123456789012345678.901,
-        ])
-    )
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_high_integer_and_decimals():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([123456789012345.6789]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_14_digits():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([12345678901.234]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 3
-
-
-def test_learn_rounding_digits_15_digits():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([12345678901.2345]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 4
-
-
-def test_learn_rounding_digits_too_many_digits_no_int():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([0.1234567890123456]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_many_decimlas():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([0.123456789012345]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 15
-
-
-def test_learn_rounding_digits_integers():
-    """Test it for integers."""
-    data = pd.Series(np.array([123456789012345]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 0
-
-
-def test_learn_rounding_digits_integers_many_digits():
-    """Test it for integers."""
-    data = pd.Series(np.array([12345678901234567890]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 0
-
-
-def test_learn_rounding_digits_integers_many_digits_with_other_values():
-    """Test it for integers and decimals."""
-    data = pd.Series(np.array([12345678901234567890, 1.123]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_many_zeros():
-    """Test it for integers and decimals."""
-    data = pd.Series(np.array([0.000000000000000000001]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_negative_values():
-    """Test it for negative values."""
-    data = pd.Series(np.array([-12345678901234, -1.123]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
-
-
-def test_learn_rounding_digits_negative_value_15_decimals():
-    """Test it for high digit counts."""
-    data = pd.Series(np.array([-0.123456789012345]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 15
+    # Run tests
+    for i, (data, expected) in enumerate(test_cases, 1):
+        output = learn_rounding_digits(data)
+        assert output == expected, f'Test case {i} failed: expected {expected}, got {output}'
 
 
 def test_learn_rounding_digits_pyarrow():
@@ -399,54 +312,6 @@ def test_learn_rounding_digits_pyarrow_float():
 
     # Assert
     assert output == 2
-
-
-def test_learn_rounding_digits_negative_decimals_float():
-    """Test the learn_rounding_digits method with floats multiples of powers of 10.
-
-    If the data has all multiples of 10 the output should be 0.
-
-    Input:
-    - An array that contains floats that are multiples of powers of 10, 100 and 1000 and a NaN.
-    """
-    data = pd.Series(np.array([1230.0, 12300.0, 123000.0, np.nan]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 0
-
-
-def test_learn_rounding_digits_negative_decimals_integer():
-    """Test the learn_rounding_digits method with integers multiples of powers of 10.
-
-    If the data has all multiples of 10 the output should be 0.
-
-    Input:
-    - An array that contains integers that are multiples of powers of 10, 100 and 1000
-        and a NaN.
-    """
-    data = pd.Series(np.array([1230, 12300, 123000, np.nan]))
-
-    output = learn_rounding_digits(data)
-
-    assert output == 0
-
-
-def test_learn_rounding_digits_all_missing_value_replacements():
-    """Test the learn_rounding_digits method with data that is all NaNs.
-
-    If the data is all NaNs, expect that the output is None.
-
-    Input:
-    - An array of NaN.
-    Output:
-    - None
-    """
-    data = pd.Series(np.array([np.nan, np.nan, np.nan, np.nan]))
-
-    output = learn_rounding_digits(data)
-
-    assert output is None
 
 
 def test_learn_rounding_digits_nullable_numerical_pandas_dtypes():


### PR DESCRIPTION
CU-86b455jpu, Resolve https://github.com/datacebo/SDV-Enterprise/issues/1107.

A float64 has 15-17 digits of precision. Anything after that should be disconsidered. For example:
```
f"{np.float64(0.1):.15f}" -> '0.100000000000000'
f"{np.float64(0.1):.20f}" -> '0.10000000000000000555'
```

These 15-17 digits include the integer part of the number, for example:
```
f"{np.float64(100.1):.12f}" -> '100.100000000000'
f"{np.float64(100.1):.15f}" -> '100.099999999999994'
```

The previous implementation always attempted to round to `MAX_DECIMALS - 1` digits, ie 14 decimal places, which could fail for cases like above where there's an integer component to the number:
```
np.float64(944343.1221).round(13) -> 944343.1220999999
np.float64(944343.1221).round(12) -> 944343.1221
```

This PR fixes this issue by rounding to `MAX_DECIMALS - num_integer_digits` instead, ensuring the situation above never happens.