### PR TITLE
Revert "Rename IDGenerator to IndexGenerator (#960)"

### DIFF
--- a/rdt/transformers/__init__.py
+++ b/rdt/transformers/__init__.py
@@ -22,7 +22,7 @@ from rdt.transformers.datetime import (
     OptimizedTimestampEncoder,
     UnixTimestampEncoder,
 )
-from rdt.transformers.id import IDGenerator, IndexGenerator, RegexGenerator
+from rdt.transformers.id import IDGenerator, RegexGenerator
 from rdt.transformers.null import NullTransformer
 from rdt.transformers.numerical import (
     ClusterBasedNormalizer,
@@ -57,7 +57,6 @@ __all__ = [
     'AnonymizedFaker',
     'PseudoAnonymizedFaker',
     'IDGenerator',
-    'IndexGenerator',
     'get_transformer_name',
     'get_transformer_class',
     'get_transformers_by_type',

--- a/rdt/transformers/id.py
+++ b/rdt/transformers/id.py
@@ -12,7 +12,7 @@ from rdt.transformers.utils import strings_from_regex
 LOGGER = logging.getLogger(__name__)
 
 
-class IndexGenerator(BaseTransformer):
+class IDGenerator(BaseTransformer):
     """Generate an ID column.
 
     This transformer generates an ID column based on a given prefix, starting value and suffix.
@@ -70,21 +70,6 @@ class IndexGenerator(BaseTransformer):
         self._counter += len(data)
 
         return pd.Series(values)
-
-
-class IDGenerator(IndexGenerator):
-    """Deprecated class name for ``IndexGenerator``.
-
-    Class to ensure backwards compatibility with previous versions of RDT.
-    """
-
-    def __init__(self, prefix=None, starting_value=0, suffix=None):
-        warnings.warn(
-            "The 'IDGenerator' has been renamed to 'IndexGenerator'. Please update the"
-            'name to ensure compatibility with future versions of RDT.',
-            FutureWarning,
-        )
-        super().__init__(prefix, starting_value, suffix)
 
 
 class RegexGenerator(BaseTransformer):

--- a/tests/integration/transformers/test_id.py
+++ b/tests/integration/transformers/test_id.py
@@ -4,12 +4,12 @@ import numpy as np
 import pandas as pd
 
 from rdt import HyperTransformer, get_demo
-from rdt.transformers.id import IndexGenerator, RegexGenerator
+from rdt.transformers.id import IDGenerator, RegexGenerator
 
 
-class TestIndexGenerator:
+class TestIDGenerator:
     def test_end_to_end(self):
-        """End to end test of the ``IndexGenerator``."""
+        """End to end test of the ``IDGenerator``."""
         # Setup
         data = pd.DataFrame({
             'id': [1, 2, 3, 4, 5],
@@ -17,7 +17,7 @@ class TestIndexGenerator:
         })
 
         # Run
-        transformer = IndexGenerator(prefix='id_', starting_value=100, suffix='_X')
+        transformer = IDGenerator(prefix='id_', starting_value=100, suffix='_X')
         transformed = transformer.fit_transform(data, 'id')
         reverse_transform = transformer.reverse_transform(transformed)
         reverse_transform_2 = transformer.reverse_transform(transformed)

--- a/tests/unit/transformers/test_id.py
+++ b/tests/unit/transformers/test_id.py
@@ -1,6 +1,5 @@
 """Test for ID transformers."""
 
-import re
 from string import ascii_uppercase
 from unittest.mock import Mock, patch
 
@@ -8,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from rdt.transformers.id import IDGenerator, IndexGenerator, RegexGenerator
+from rdt.transformers.id import IDGenerator, RegexGenerator
 
 
 class AsciiGenerator:
@@ -31,11 +30,11 @@ class AsciiGenerator:
         return char
 
 
-class TestIndexGenerator:
+class TestIDGenerator:
     def test___init__default(self):
         """Test the ``__init__`` method."""
         # Run
-        transformer = IndexGenerator()
+        transformer = IDGenerator()
 
         # Assert
         assert transformer.prefix is None
@@ -47,10 +46,10 @@ class TestIndexGenerator:
     def test___init__with_parameters(self):
         """Test the ``__init__`` method with paremeters."""
         # Run
-        transformer_prefix = IndexGenerator(prefix='prefix_')
-        transformer_suffix = IndexGenerator(suffix='_suffix')
-        transformer_starting_value = IndexGenerator(starting_value=10)
-        transformer_all = IndexGenerator(prefix='prefix_', starting_value=10, suffix='_suffix')
+        transformer_prefix = IDGenerator(prefix='prefix_')
+        transformer_suffix = IDGenerator(suffix='_suffix')
+        transformer_starting_value = IDGenerator(starting_value=10)
+        transformer_all = IDGenerator(prefix='prefix_', starting_value=10, suffix='_suffix')
 
         # Assert
         assert transformer_prefix.prefix == 'prefix_'
@@ -80,7 +79,7 @@ class TestIndexGenerator:
     def test_reset_randomization(self):
         """Test the ``reset_randomization`` method."""
         # Setup
-        transformer = IndexGenerator()
+        transformer = IDGenerator()
         transformer._counter = 10
 
         # Run
@@ -92,7 +91,7 @@ class TestIndexGenerator:
     def test__fit(self):
         """Test the ``_fit`` method."""
         # Setup
-        transformer = IndexGenerator()
+        transformer = IDGenerator()
 
         # Run
         transformer._fit(None)
@@ -103,7 +102,7 @@ class TestIndexGenerator:
     def test__transform(self):
         """Test the ``_transform`` method."""
         # Setup
-        transformer = IndexGenerator()
+        transformer = IDGenerator()
 
         # Run
         result = transformer._transform(None)
@@ -114,7 +113,7 @@ class TestIndexGenerator:
     def test__reverse_transform(self):
         """Test the ``_reverse_transform`` method."""
         # Setup
-        transformer = IndexGenerator()
+        transformer = IDGenerator()
         transformer._counter = 10
 
         # Run
@@ -128,7 +127,7 @@ class TestIndexGenerator:
     def test__reverse_transform_with_everything(self):
         """Test the ``_reverse_transform`` method with all parameters."""
         # Setup
-        transformer = IndexGenerator(prefix='prefix_', starting_value=100, suffix='_suffix')
+        transformer = IDGenerator(prefix='prefix_', starting_value=100, suffix='_suffix')
 
         # Run
         result = transformer._reverse_transform(np.array([1, 2, 3]))
@@ -141,17 +140,6 @@ class TestIndexGenerator:
             'prefix_102_suffix',
         ]
         assert transformer._counter == 3
-
-
-class TestIDGenerator:
-    def test___init__(self):
-        """Test the warning message for ``IDGenerator``."""
-        msg = re.escape(
-            "The 'IDGenerator' has been renamed to 'IndexGenerator'. Please update the"
-            'name to ensure compatibility with future versions of RDT.'
-        )
-        with pytest.warns(FutureWarning, match=msg):
-            IDGenerator(prefix='prefix_', starting_value=100, suffix='_suffix')
 
 
 class TestRegexGenerator:


### PR DESCRIPTION
This reverts commit cdbd596f3a5ea6f63c4b366d0b1c726bbe3558b2. We want to do a patch release of RDT so we would like to move this change off for now and merge it back in later.