### PR TITLE
Synthetic data contains all nulls with some RDTs, with min/max enforcement enabled, and null column learning enabled

### DIFF
--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -210,10 +210,10 @@ class UnixTimestampEncoder(BaseTransformer):
         Returns:
             pandas.Series
         """
+        data = self._reverse_transform_helper(data)
         if self.enforce_min_max_values:
             data = data.clip(self._min_value, self._max_value)
 
-        data = self._reverse_transform_helper(data)
         datetime_data = pd.to_datetime(data)
         if self.datetime_format:
             if is_datetime64_dtype(self._dtype) and '.%f' not in self.datetime_format:

--- a/tests/unit/transformers/test_datetime.py
+++ b/tests/unit/transformers/test_datetime.py
@@ -530,6 +530,27 @@ class TestUnixTimestampEncoder:
         expected = pd.Series([np.nan, np.nan, np.nan])
         pd.testing.assert_series_equal(output, expected)
 
+    def test__reverse_transform_missing_value_generation_from_column(self):
+        """Test ``_reverse_transform`` method with `missing_value_generation` is `from_column`."""
+        # Setup
+        transformer = UnixTimestampEncoder(missing_value_generation='from_column')
+        transformed = pd.DataFrame({
+            'date': [1.5778368e18, 1.5805152e18, 1.5830208e18],
+            'date.is_null': [0.1, 0.6, 0.1],
+        })
+        transformer._min_value = 1.5778368e18
+        transformer._max_value = 1.5830208e18
+        transformer.null_transformer = NullTransformer(missing_value_generation='from_column')
+        transformer.null_transformer.nulls = True
+        transformer.enforce_min_max_values = True
+
+        # Run
+        result = transformer._reverse_transform(transformed)
+
+        # Assert
+        expected = pd.Series(pd.to_datetime(['2020-01-01', np.nan, '2020-03-01']))
+        pd.testing.assert_series_equal(result, expected)
+
     def test__set_fitted_parameters(self):
         """Test the ``_set_fitted_parameters`` method."""
         # Setup


### PR DESCRIPTION
Resolve #939
CU-86b3vq4pm

@frances-h, @amontanez24, this is the result of the small investigation using the code provided in the issue:
- Before this PR:
     ```
     Null percentage in synthetic data: 100.0 %
     Null percentage in real data: 20.0 %
     ```
- After this PR:
     ```
     Null percentage in synthetic data: 3.0 %
     Null percentage in real data: 20.0 %
     ```
- With a UniformEncoder used to make the flag column continuous:
     ```
     Null percentage in synthetic data: 21.0 %
     Null percentage in real data: 20.0 %
     ```

To get the last result (with UniformEncoder) here is how I updated the code from the issue:
```python
# Setup
uniform_encoder = UniformEncoder()
synthesizer.update_transformers(column_name_to_transformer=column_name_to_transformer)
preprocess_data = synthesizer.preprocess(data)
preprocess_data = uniform_encoder.fit_transform(preprocess_data, column='date.is_null')

# Fit
synthesizer.fit_processed_data(preprocess_data)

# Sample
synthetic_data = synthesizer._sample(len(data))
synthetic_data = uniform_encoder.reverse_transform(synthetic_data)
synthetic_data = synthesizer._data_processor.reverse_transform(synthetic_data)
```