### PR TITLE
UnixTimestampEncoder: Fix reverse transform missing timezone information for UTC datetime data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,4 +110,4 @@ ENV/
 .DS_Store
 
 # Vim
-.*.swp
+*.swp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "scikit-learn>=1.3.1;python_version>='3.12' and python_version<'3.13'",
     "scikit-learn>=1.5.2;python_version>='3.13'",
     'Faker>=17',
+    'python-dateutil>=2.9',
 ]
 
 [project.urls]

--- a/rdt/transformers/datetime.py
+++ b/rdt/transformers/datetime.py
@@ -86,7 +86,6 @@ class UnixTimestampEncoder(BaseTransformer):
             try:
                 self._learn_has_multiple_timezones(data)
                 parsed_data = self._to_datetime(data)
-                self._warn_if_mixed_timezones()
                 return parsed_data
 
             except ValueError as error:
@@ -109,7 +108,9 @@ class UnixTimestampEncoder(BaseTransformer):
 
     def _warn_if_mixed_timezones(self):
         if self._has_multiple_timezones:
-            warnings.warn('Mixed timezones are supported only in SDV Enterprise.')
+            warnings.warn(
+                'Mixed timezones are not supported in SDV Community. Data will be converted to UTC.'
+            )
 
     def _raise_appropiate_conversion_error(self, error):
         message = str(error)
@@ -165,6 +166,8 @@ class UnixTimestampEncoder(BaseTransformer):
         transformed = self._transform_helper(data)
 
         self._learn_timezone_offest(data)
+        self._warn_if_mixed_timezones()
+
         if self.enforce_min_max_values:
             self._min_value = transformed.min()
             self._max_value = transformed.max()

--- a/rdt/transformers/utils.py
+++ b/rdt/transformers/utils.py
@@ -12,6 +12,8 @@ from decimal import Decimal
 import numpy as np
 import pandas as pd
 from dateutil import parser
+from dateutil.parser import UnknownTimezoneWarning
+from dateutil.tz import UTC
 
 import sre_parse  # isort:skip
 
@@ -387,19 +389,62 @@ def _handle_enforce_uniqueness_and_cardinality_rule(enforce_uniqueness, cardinal
     return result
 
 
-def _safe_parse_datetime(value):
+def _extract_timezone_from_a_string(dt_str):
+    if not isinstance(dt_str, str):
+        dt_str = str(dt_str)
+
+    match = re.search(r'\b([A-Z]{2,5})\b', dt_str)
+    return match.group(1) if match else None
+
+
+def _safe_parse_datetime(value, warn=False):
+    """Safely parse a value into a datetime object, handling invalid inputs.
+
+    Converts the input `value` into a `datetime.datetime` object using `dateutil.parser.parse`.
+    If the input is already a `pandas.Timestamp` or `datetime.datetime`, it is returned unchanged.
+    Unrecognized timezones are converted to UTC, with an optional warning. Returns `pd.NaT` if
+    parsing fails or the input is invalid.
+
+    Args:
+        value (Any):
+            Value to parse into a datetime. Accepts strings, `pandas.Timestamp`,
+            `datetime.datetime`, or types compatible with `dateutil.parser.parse`.
+        warn (bool):
+            If True, warns when an unrecognized timezone is converted to UTC.
+            Defaults to False.
+
+    Returns:
+        datetime.datetime | pd.NaT:
+            Parsed `datetime.datetime` object with unrecognized timezones
+            set to UTC, or `pd.NaT` if parsing fails.
+    """
     if isinstance(value, (pd.Timestamp, datetime.datetime)):
         return value
+
     try:
-        return parser.parse(value)
-    except Exception:
+        with warnings.catch_warnings(record=True) as captured_warnings:
+            dt = parser.parse(value)
+
+        if any(issubclass(warned.category, UnknownTimezoneWarning) for warned in captured_warnings):
+            input_timezone = _extract_timezone_from_a_string(value)
+            if warn:
+                warnings.warn(
+                    f"Timezone '{input_timezone}' is not understood so it will be converted "
+                    "to 'UTC'.",
+                )
+
+            return dt.replace(tzinfo=UTC)
+
+        return dt
+
+    except (ValueError, TypeError, AttributeError):
         return None
 
 
 def _get_utc_offset(dt):
     try:
         return dt.utcoffset()
-    except Exception:
+    except AttributeError:
         return None
 
 
@@ -419,5 +464,5 @@ def data_has_multiple_timezones(data):
         offsets = parsed_datetimes.apply(_get_utc_offset).dropna()
         return offsets.nunique() > 1
 
-    except Exception:
+    except ValueError:
         return False

--- a/tests/integration/transformers/test_datetime.py
+++ b/tests/integration/transformers/test_datetime.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_datetime64_ns_dtype, is_datetime64tz_dtype
 
 from rdt.transformers.datetime import (
     OptimizedTimestampEncoder,
@@ -284,6 +285,126 @@ class TestUnixTimestampEncoder:
 
         # Asserts
         pd.testing.assert_frame_equal(output, data)
+
+    def test_datetime_strings_with_timezone_name(self):
+        """Ensure datetime strings containing timezone names (%Z) are handled correctly.
+
+        This test verifies that datetime strings with explicit timezone names like 'UTC'
+        are properly parsed, transformed into timestamps, and then accurately
+        reverse-transformed back into strings that preserve the original timezone label.
+
+        Specifically:
+            - The format '%Z' should recognize and retain the 'UTC' suffix.
+            - The reverse-transformed output should match the original input values.
+            - The resulting dtype should remain string-based, not tz-aware datetime64.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'my_datetime_col': ['2025-02-04 08:32:21.123456 UTC', '2025-01-13 08:32:21.123456 UTC']
+        })
+        transformer = UnixTimestampEncoder(datetime_format='%Y-%m-%d %H:%M:%S.%f %Z')
+
+        # Run
+        transformer.fit(data, column='my_datetime_col')
+        transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
+        transformed = transformer.transform(data)
+        reverse_transformed = transformer.reverse_transform(transformed)
+
+        # Assert
+        assert reverse_transformed['my_datetime_col'].iloc[0].endswith('UTC')
+        assert reverse_transformed['my_datetime_col'].iloc[1].endswith('UTC')
+        pd.testing.assert_frame_equal(data, reverse_transformed)
+        assert not is_datetime64tz_dtype(reverse_transformed['my_datetime_col'])
+
+    def test_datetime_strings_with_timezone_offset(self):
+        """Ensure datetime strings with timezone offsets (%z) are correctly parsed and normalized.
+
+        This test verifies that datetime strings with timezone offsets (e.g., '+0200') are:
+            - Properly parsed using the '%z' directive.
+            - Converted to UTC during transformation.
+            - Reverse-transformed back into strings using the same format,
+              with the offset normalized to '+0000'.
+
+        The test also asserts that the time is adjusted correctly to UTC (e.g., 08:32+0200
+        becomes 06:32+0000), and that the reverse-transformed output matches
+        the expected normalized strings.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'my_datetime_col': ['2025-02-04 08:32:20+0200', '2025-01-13 08:32:21+0200']
+        })
+        transformer = UnixTimestampEncoder(datetime_format='%Y-%m-%d %H:%M:%S%z')
+
+        # Run
+        transformer.fit(data, column='my_datetime_col')
+        transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
+        transformed = transformer.transform(data)
+        reverse_transformed = transformer.reverse_transform(transformed)
+
+        # Assert
+        assert all(reverse_transformed['my_datetime_col'].str.endswith('+0000'))
+        expected_data = pd.DataFrame({
+            'my_datetime_col': ['2025-02-04 06:32:20+0000', '2025-01-13 06:32:21+0000']
+        })
+        pd.testing.assert_frame_equal(expected_data, reverse_transformed)
+        assert not is_datetime64tz_dtype(reverse_transformed)
+
+    def test_datetime_objects_with_timezone_info_and_no_format(self):
+        """Ensure naive datetime objects are preserved during reverse transform with no format.
+
+        This test verifies that when datetime64 objects without timezone info
+        (i.e., naive datetimes) are used as input and no datetime format is
+        specified:
+            - The values are correctly transformed and reverse-transformed without
+              introducing timezone information.
+            - The resulting dtype remains timezone-naive (`datetime64[ns, UTC]`).
+            - The reverse-transformed output matches the original input exactly.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'my_datetime_col': pd.to_datetime(
+                ['2025-02-04 08:32:21.123456 UTC', '2025-01-13 08:32:21.123456 UTC'], utc=True
+            )
+        })
+        transformer = UnixTimestampEncoder(datetime_format=None)
+
+        # Run
+        transformer.fit(data, column='my_datetime_col')
+        transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
+        transformed = transformer.transform(data)
+        reverse_transformed = transformer.reverse_transform(transformed)
+
+        # Assert
+        assert is_datetime64tz_dtype(reverse_transformed['my_datetime_col'])
+        pd.testing.assert_frame_equal(data, reverse_transformed)
+
+    def test_datetime_objects_without_timezone_and_no_format(self):
+        """Ensure datetime objects without timezone are correctly handled when no format is given.
+
+        This test verifies that naive datetime64 values (i.e., without timezone info) are:
+            - Properly transformed and reverse-transformed without introducing any timezone.
+            - Preserved with a timezone-naive dtype (`datetime64[ns]`) throughout.
+            - Returned exactly as the original input after the reverse transformation.
+        """
+        # Setup
+        data = pd.DataFrame({
+            'my_datetime_col': pd.to_datetime([
+                '2025-02-04 08:32:21.123456',
+                '2025-01-13 08:32:21.123456',
+            ])
+        })
+        transformer = UnixTimestampEncoder(datetime_format=None)
+
+        # Run
+        transformer.fit(data, column='my_datetime_col')
+        transformer.set_random_state(np.random.RandomState(42), 'reverse_transform')
+        transformed = transformer.transform(data)
+        reverse_transformed = transformer.reverse_transform(transformed)
+
+        # Assert
+        assert is_datetime64_ns_dtype(reverse_transformed['my_datetime_col'])
+        assert not is_datetime64tz_dtype(reverse_transformed['my_datetime_col'])
+        pd.testing.assert_frame_equal(data, reverse_transformed)
 
 
 class TestOptimizedTimestampEncoder:

--- a/tests/unit/transformers/test_datetime.py
+++ b/tests/unit/transformers/test_datetime.py
@@ -733,7 +733,9 @@ class TestUnixTimestampEncoder:
         instance._has_multiple_timezones = True
 
         # Run
-        warning_msg = 'Mixed timezones are supported only in SDV Enterprise.'
+        warning_msg = (
+            'Mixed timezones are not supported in SDV Community. Data will be converted to UTC.'
+        )
         with pytest.warns(UserWarning, match=warning_msg):
             UnixTimestampEncoder._warn_if_mixed_timezones(instance)
 

--- a/tests/unit/transformers/test_utils.py
+++ b/tests/unit/transformers/test_utils.py
@@ -9,8 +9,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pandas as pd
 import pytest
-from dateutil import parser
-from zoneinfo import ZoneInfo
+from dateutil import parser, tz
 
 from rdt.transformers.utils import (
     WarnDict,
@@ -572,7 +571,7 @@ def test__safe_parse_datetime_with_unrecognized_timezone_and_warning():
     # Setup
     value = '2023-10-15 14:30:00 XYZ'
     warn = True
-    expected_dt = parser.parse('2023-10-15 14:30:00').replace(tzinfo=ZoneInfo('UTC'))
+    expected_dt = parser.parse('2023-10-15 14:30:00').replace(tzinfo=tz.tzoffset('UTC', 0))
 
     # Run
     warning_msg = "Timezone 'XYZ' is not understood so it will be converted to 'UTC'."


### PR DESCRIPTION
Resolves #987 
CU-86b4tkdmn

This pull request also modularizes the code base for the `UnixTimestampEncoder` in order to help us overwrite methods in future if required.

### Additional changes:
* Fallback to `UTC` if the timezone used is dubious.
    * Warnings are being displayed if the transformer has to fallback to this default.
    * This only happens when your data looks like: `2025-05-01 22:03:40 EST` and the dateutil library can't determine which EST zone you are referring to.

* Added `python-dateutil` library as requirement in order to easily parse the input datetime strings to timezone aware objects.
